### PR TITLE
Publish events across cluster

### DIFF
--- a/lib/events.ex
+++ b/lib/events.ex
@@ -99,6 +99,10 @@ defmodule Cluster.Events do
             loop(subscribers, parent, debug)
         end
       {:publish, event} = msg ->
+        debug = handle_debug(debug, {:out, msg})
+        for node <- Node.list(), do: send({__MODULE__, node}, {:receive, event})
+        loop(subscribers, parent, debug)
+      {:receive, event} = msg ->
         debug = handle_debug(debug, {:in, msg})
         for {pid, _} <- subscribers, do: send(pid, event)
         loop(subscribers, parent, debug)


### PR DESCRIPTION
Closes #2 

This code takes advantage of the fact that each node in the cluster has `Cluster.Events` worker running on it. So we can pass events between these workers, and then each worker will delegate it to whichever subscribers there are on that that node.

Old `publish` is renamed to `receive`, while new `publish` now sends messages across node's `Cluster.Events` worker.
