### PR TITLE
Fix Kubernetes strategy

### DIFF
--- a/lib/strategy/strategy.ex
+++ b/lib/strategy/strategy.ex
@@ -100,8 +100,8 @@ defmodule Cluster.Strategy do
     end
   end
 
-  def intersection(a, []), do: a
-  def intersection([], b), do: b
+  def intersection(a, []), do: []
+  def intersection([], b), do: []
   def intersection(a, b) when is_list(a) and is_list(b) do
     a |> MapSet.new |> MapSet.intersection(MapSet.new(b))
   end

--- a/lib/strategy/strategy.ex
+++ b/lib/strategy/strategy.ex
@@ -107,7 +107,7 @@ defmodule Cluster.Strategy do
   end
 
   def difference(a, []), do: a
-  def difference([], b), do: b
+  def difference([], b), do: []
   def difference(a, b) when is_list(a) and is_list(b) do
     a |> MapSet.new |> MapSet.difference(MapSet.new(b))
   end


### PR DESCRIPTION
2.1.0 broke the Kuberenetes strategy.

It would end up in an infinite loop due to the way https://github.com/bitwalker/libcluster/blob/master/lib/strategy/kubernetes.ex#L55 worked in combination with the implementation of `intersection/2`. And the implementation of `difference` led to excessively reconnecting.

This should hopefully fix that!