### PR TITLE
Ignore heartbeats from self in gossip strategy.

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -107,7 +107,10 @@ defmodule Cluster.Strategy.Gossip do
   # is different, and thus a node we can ignore
   @spec handle_heartbeat(State.t, binary) :: :ok
   defp handle_heartbeat(%State{connect: connect, list_nodes: list_nodes} = state, <<"heartbeat::", rest::binary>>) do
+    self = node()
     case :erlang.binary_to_term(rest) do
+      %{node: ^self} ->
+        :ok
       %{node: n} when is_atom(n) ->
         debug state.topology, "received heartbeat from #{n}"
         Cluster.Strategy.connect_nodes(state.topology, connect, list_nodes, [n])


### PR DESCRIPTION
Without this, the `info` logs get spammed with `connected to` messages from itself.  But a connection to itself never happens, so it keeps logging.