### PR TITLE
do not force :ok for udp.send the network may be unreachable

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -80,7 +80,7 @@ defmodule Cluster.Strategy.Gossip do
   def handle_info(:timeout, state), do: handle_info(:heartbeat, state)
   def handle_info(:heartbeat, %State{meta: {multicast_addr, port, socket}} = state) do
     debug state.topology, "heartbeat"
-    :ok = :gen_udp.send(socket, multicast_addr, port, heartbeat(node()))
+    :gen_udp.send(socket, multicast_addr, port, heartbeat(node()))
     Process.send_after(self(), :heartbeat, :rand.uniform(5_000))
     {:noreply, state}
   end


### PR DESCRIPTION
I've been doing some testing with libcluster and the udp strategy for clustering Nerves nodes and identified a few issues.

**What this PR covers**

One problem that I encountered is that since the network is unreachable when the erlang node starts,  the supervisor would flap the gossip process until max restart intensity would cause the main application init sequence to be halted. Removing the hard check for `:ok` allows the broadcast of the heartbeat to eventually work. 

**What it does not cover**

While testing I have noticed that there are some underlying issues with gen_udp and monitoring a membership to a multicast group. As far as I can see, `:gen_udp.open` is the only place where you can change udp multicast group memberships. By fixing the problem above, the node it then capable of sending heart beats, but it is not able to receive them. I am able to work around this issue by stopping and starting the `:libcluster` application when the interface had been bound. I wanted to bring this up since its an important note, but also to start a conversation about what we could do to monitor udp multicast group memberships.