### PR TITLE
Strategy to poll a json endpoint for the node list.

### DIFF
--- a/lib/strategy/json.ex
+++ b/lib/strategy/json.ex
@@ -1,0 +1,14 @@
+defmodule Cluster.Strategy.Poll.Json do
+  use Cluster.Strategy.Poll
+
+  @spec get_nodes(State.t) :: [atom()]
+  defp get_nodes(%State{topology: topology, config: config}) do
+    config
+    |> Keyword.get(:url)
+    |> HTTPoison.get!
+    |> Map.get(:body)
+    |> Poison.decode!
+    |> Map.get("data")
+    |> Enum.map(&String.to_atom/1)
+  end
+end

--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -1,4 +1,4 @@
-defmodule Cluster.Strategy.Kubernetes do
+defmodule Cluster.Strategy.Poll.Json do
   @moduledoc """
   This clustering strategy works by loading all endpoints in the current Kubernetes
   namespace with the configured label. It will fetch the addresses of all endpoints with
@@ -56,60 +56,10 @@ defmodule Cluster.Strategy.Kubernetes do
               polling_interval: 10_000]]]
 
   """
-  use GenServer
-  use Cluster.Strategy
-  import Cluster.Logger
+  use Cluster.Strategy.Poll
 
-  alias Cluster.Strategy.State
-
-  @default_polling_interval 5_000
   @kubernetes_master    "kubernetes.default.svc.cluster.local"
   @service_account_path "/var/run/secrets/kubernetes.io/serviceaccount"
-
-  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
-  def init(opts) do
-    state = %State{
-      topology: Keyword.fetch!(opts, :topology),
-      connect: Keyword.fetch!(opts, :connect),
-      disconnect: Keyword.fetch!(opts, :disconnect),
-      list_nodes: Keyword.fetch!(opts, :list_nodes),
-      config: Keyword.fetch!(opts, :config),
-      meta: MapSet.new([])
-    }
-    {:ok, state, 0}
-  end
-
-  def handle_info(:timeout, state) do
-    handle_info(:load, state)
-  end
-  def handle_info(:load, %State{topology: topology, connect: connect, disconnect: disconnect, list_nodes: list_nodes} = state) do
-    new_nodelist = MapSet.new(get_nodes(state))
-    added        = MapSet.difference(new_nodelist, state.meta)
-    removed      = MapSet.difference(state.meta, new_nodelist)
-    new_nodelist = case Cluster.Strategy.disconnect_nodes(topology, disconnect, list_nodes, MapSet.to_list(removed)) do
-                :ok ->
-                  new_nodelist
-                {:error, bad_nodes} ->
-                  # Add back the nodes which should have been removed, but which couldn't be for some reason
-                  Enum.reduce(bad_nodes, new_nodelist, fn {n, _}, acc ->
-                    MapSet.put(acc, n)
-                  end)
-              end
-    new_nodelist = case Cluster.Strategy.connect_nodes(topology, connect, list_nodes, MapSet.to_list(added)) do
-              :ok ->
-                new_nodelist
-              {:error, bad_nodes} ->
-                # Remove the nodes which should have been added, but couldn't be for some reason
-                Enum.reduce(bad_nodes, new_nodelist, fn {n, _}, acc ->
-                  MapSet.delete(acc, n)
-                end)
-            end
-    Process.send_after(self(), :load, Keyword.get(state.config, :polling_interval, @default_polling_interval))
-    {:noreply, %{state | :meta => new_nodelist}}
-  end
-  def handle_info(_, state) do
-    {:noreply, state}
-  end
 
   @spec get_token() :: String.t
   defp get_token() do

--- a/lib/strategy/poll.ex
+++ b/lib/strategy/poll.ex
@@ -1,0 +1,63 @@
+defmodule Cluster.Strategy.Poll do
+  defmacro __using__(_) do
+    quote do
+      @behaviour Cluster.Strategy.Poll
+
+      use GenServer
+      use Cluster.Strategy
+      import Cluster.Logger
+
+      alias Cluster.Strategy.State
+
+      @default_polling_interval 5_000
+
+      def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+      def init(opts) do
+        state = %State{
+          topology: Keyword.fetch!(opts, :topology),
+          connect: Keyword.fetch!(opts, :connect),
+          disconnect: Keyword.fetch!(opts, :disconnect),
+          list_nodes: Keyword.fetch!(opts, :list_nodes),
+          config: Keyword.fetch!(opts, :config),
+          meta: MapSet.new([])
+        }
+        {:ok, state, 0}
+      end
+
+      def handle_info(:timeout, state) do
+        handle_info(:load, state)
+      end
+      def handle_info(:load, %State{topology: topology, connect: connect, disconnect: disconnect, list_nodes: list_nodes} = state) do
+        new_nodelist = MapSet.new(get_nodes(state))
+        added        = MapSet.difference(new_nodelist, state.meta)
+        removed      = MapSet.difference(state.meta, new_nodelist)
+        new_nodelist = case Cluster.Strategy.disconnect_nodes(topology, disconnect, list_nodes, MapSet.to_list(removed)) do
+                    :ok ->
+                      new_nodelist
+                    {:error, bad_nodes} ->
+                      # Add back the nodes which should have been removed, but which couldn't be for some reason
+                      Enum.reduce(bad_nodes, new_nodelist, fn {n, _}, acc ->
+                        MapSet.put(acc, n)
+                      end)
+                  end
+        new_nodelist = case Cluster.Strategy.connect_nodes(topology, connect, list_nodes, MapSet.to_list(added)) do
+                  :ok ->
+                    new_nodelist
+                  {:error, bad_nodes} ->
+                    # Remove the nodes which should have been added, but couldn't be for some reason
+                    Enum.reduce(bad_nodes, new_nodelist, fn {n, _}, acc ->
+                      MapSet.delete(acc, n)
+                    end)
+                end
+        Process.send_after(self(), :load, Keyword.get(state.config, :polling_interval, @default_polling_interval))
+        {:noreply, %{state | :meta => new_nodelist}}
+      end
+      def handle_info(_, state) do
+        {:noreply, state}
+      end
+
+    end
+  end
+
+  @callback get_nodes(State.t) :: [atom()]
+end

--- a/mix.exs
+++ b/mix.exs
@@ -17,13 +17,14 @@ defmodule Cluster.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :inets, :poison, :crypto, :ssl],
+    [applications: [:logger, :inets, :poison, :crypto, :ssl, :httpoison],
      mod: {Cluster.App, []}]
   end
 
   defp deps do
     [{:ex_doc, "~> 0.13", only: :dev},
      {:dialyxir, "~> 0.3", only: :dev},
+     {:httpoison, "~> 0.13"},
      {:poison, "~> 3.0"}]
   end
 


### PR DESCRIPTION
Hello!

This is a strategy very similar to the Kubernetes strategy that simply polls a json endpoint for the node list to connect to.

I tested this within my own app, but haven't tested it as implemented here in libcluster, but wanted to send it over to see if you'd consider accepting something like this. If you like the idea, then I'll clean it up and test it thoroughly.

I can see this being useful for a number of use cases, but in my use case, I want to connect two clusters together to form a heterogeneous cluster. The clusters each expose a `/nodes_ ` endpoint that returns their list of Nodes. This strategy polls than endpoint very similarly to how the Kubernetes strategy polls the Kubernetes' "endpoints" endpoint.

The configuration in `prod.exs` will be something like
```
config :libcluster,
  topologies: [
    poll_json_example: [
      strategy: Cluster.Strategy.Poll.Json,
      config: [
        url: "https://example.com/nodes_"
      ]
    ]
```

The `/nodes_` endpoint for `example.com` should be something like
```
def nodes(conn, params) do
  json conn, %{
    data: Node.list ++ [Node.self]
  }
end
```

Let me know what you think. I refactored the common elements out into a `Cluster.Strategy.Poll` strategy. Happy to make changes also.