### PR TITLE
Whitelist defined topologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ which will be used.
 
 ```elixir
 config :libcluster,
+  # If you want to define multiple topologies but only use a specific one depending on your env you can whitelist them here.
+  whitelisted_topologies: [:example],
   topologies: [
     example: [
       # The selected clustering strategy. Required.

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@
 use Mix.Config
 
 config :libcluster,
+  # You can cherry pick specific topologies 
+  applied_topologies: [:example],
   # You can start clustering for one or more topologies.
   topologies: [
     example: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,7 @@
 use Mix.Config
 
 config :libcluster,
-  # You can whitelsit some of the defined topologies 
+  # You can whitelist some of the defined topologies 
   whitelisted_topologies: [:example],
   # You can start clustering for one or more topologies.
   topologies: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,8 +2,8 @@
 use Mix.Config
 
 config :libcluster,
-  # You can cherry pick specific topologies 
-  applied_topologies: [:example],
+  # You can whitelsit some of the defined topologies 
+  whitelisted_topologies: [:example],
   # You can start clustering for one or more topologies.
   topologies: [
     example: [

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -13,7 +13,7 @@ defmodule Cluster.App do
   defp get_child_specs() do
     import Supervisor.Spec, warn: false
     Application.get_env(:libcluster, :topologies, [])
-    |> Enum.filter(&filter_for_applied_topologies(&1, Application.get_env(:libcluster, :applied_topologies)))
+    |> Enum.filter(&whitelisted_topologies_filter(&1, Application.get_env(:libcluster, :whitelisted_topologies)))
     |> Enum.map(fn({topology, spec}) ->
       strategy       = Keyword.fetch!(spec, :strategy)
       config         = Keyword.get(spec, :config, [])
@@ -32,6 +32,6 @@ defmodule Cluster.App do
     end)
   end
 
-  defp filter_for_applied_topologies(_, nil), do: true
-  defp filter_for_applied_topologies({topology, _spec}, applied_topologies), do: topology in applied_topologies
+  defp whitelisted_topologies_filter(_, nil), do: true
+  defp whitelisted_topologies_filter({topology, _spec}, whitelisted_topologies), do: topology in whitelisted_topologies
 end

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -14,7 +14,7 @@ defmodule Cluster.App do
     import Supervisor.Spec, warn: false
     Application.get_env(:libcluster, :topologies, [])
     |> Enum.filter(&filter_for_applied_topologies(&1, Application.get_env(:libcluster, :applied_topologies)))
-    |> Enum.each(fn({topology, spec}) ->
+    |> Enum.map(fn({topology, spec}) ->
       strategy       = Keyword.fetch!(spec, :strategy)
       config         = Keyword.get(spec, :config, [])
       connect_mfa    = Keyword.get(spec, :connect, {:net_kernel, :connect, []})


### PR DESCRIPTION
This PR enables the whitelisting of topologies. In our case we want to choose the topology after we created a release. Therefore we need a way to define all supported topologies like gossip, ec2 etc. upfront before we can choose the topology at runtime.

__How it works:__
In case the the `whitelisted_topologies` is not defined the module works the same as before. If `whitelisted_topologies` is defined, the topologies which keys are in the listing are applied.