### PR TITLE
Fix docs example typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ http://erlang.org/doc/man/net_adm.html#files:
  > File `.hosts.erlang` consists of a number of host names written as Erlang terms. It is looked for in the current work
  > directory, the user's home directory, and $OTP_ROOT (the root directory of Erlang/OTP), in that order.
 
- #Example:
+## Example:
 
 ```erlang
 'super.eua.ericsson.se'.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This can be configured using the following settings:
 config :libcluster,
   topologies: [
     erlang_hosts_example: [
-      strategy: Cluster.Strategy.ErlangHosts}]]
+      strategy: Cluster.Strategy.ErlangHosts]]
 ```
 
 


### PR DESCRIPTION
Fixed two typos/formatting issues in the readme.