### PR TITLE
try to fix travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ elixir:
   - 1.5
   - 1.6
 otp_release:
-  - 19
-  - 20
+  - 19.3
+  - 20.2
 script: "MIX_ENV=test mix do deps.get, test"
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.5
   - 1.6
 otp_release:
   - 19.3


### PR DESCRIPTION
For Erlang - it is necessary to specify major.minor otherwise Travis crashes while downloading the versions - https://travis-ci.org/bryanhuntesl/libcluster/builds/349500557

The build on Elixir 1.5 - I don't know if this is an issue - presumably libcluster is targeted at Elixir 1.6.

If it is not an issue, I'll remove Elixir 1.5 from the matrix and create a PR to update the readme.