### PR TITLE
Enable a `debug` boolean option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,17 @@ config :libcluster,
         multicast_ttl: 1]]]
 ```
 
+Debug is deactivated by default for this clustering strategy, but it can be easily activated by configuring the application:
+
+```
+use Mix.Config
+
+config :libcluster,
+  debug: true
+```
+
+All the checks are done at runtime, so you can flip the debug level without being forced to shutdown your node.
+
 The Kubernetes strategy works by querying the Kubernetes API for all endpoints in the same namespace which match the provided
 selector, and getting the container IPs associated with them. Once all of the matching IPs have been found, it will attempt to
 establish node connections using the format `<kubernetes_node_basename>@<endpoint ip>`. You must make sure that your nodes are

--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -2,7 +2,11 @@ defmodule Cluster.Logger do
   @moduledoc false
   require Logger
 
-  def debug(t, msg), do: log(:debug, t, msg)
+  def debug(t, msg) do 
+    if Application.get_env(:libcluster, :debug, false) do
+      log(:debug, t, msg)
+    end
+  end
   def info(t, msg),  do: log(:info, t, msg)
   def warn(t, msg),  do: log(:warn, t, msg)
   def error(t, msg), do: log(:error, t, msg)

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -79,9 +79,7 @@ defmodule Cluster.Strategy.Gossip do
   # Send stuttered heartbeats
   def handle_info(:timeout, state), do: handle_info(:heartbeat, state)
   def handle_info(:heartbeat, %State{meta: {multicast_addr, port, socket}} = state) do
-    if Application.get_env(:libcluster, :debug, false) do
-      debug state.topology, "heartbeat"
-    end
+    debug state.topology, "heartbeat"
     :gen_udp.send(socket, multicast_addr, port, heartbeat(node()))
     Process.send_after(self(), :heartbeat, :rand.uniform(5_000))
     {:noreply, state}
@@ -114,9 +112,7 @@ defmodule Cluster.Strategy.Gossip do
       %{node: ^self} ->
         :ok
       %{node: n} when is_atom(n) ->
-        if Application.get_env(:libcluster, :debug, false) do
-          debug state.topology, "received heartbeat from #{n}"
-        end
+        debug state.topology, "received heartbeat from #{n}"
         Cluster.Strategy.connect_nodes(state.topology, connect, list_nodes, [n])
         :ok
       _ ->

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -79,7 +79,9 @@ defmodule Cluster.Strategy.Gossip do
   # Send stuttered heartbeats
   def handle_info(:timeout, state), do: handle_info(:heartbeat, state)
   def handle_info(:heartbeat, %State{meta: {multicast_addr, port, socket}} = state) do
-    debug state.topology, "heartbeat"
+    if Application.get_env(:libcluster, :debug, false) do
+      debug state.topology, "heartbeat"
+    end
     :gen_udp.send(socket, multicast_addr, port, heartbeat(node()))
     Process.send_after(self(), :heartbeat, :rand.uniform(5_000))
     {:noreply, state}
@@ -112,7 +114,9 @@ defmodule Cluster.Strategy.Gossip do
       %{node: ^self} ->
         :ok
       %{node: n} when is_atom(n) ->
-        debug state.topology, "received heartbeat from #{n}"
+        if Application.get_env(:libcluster, :debug, false) do
+          debug state.topology, "received heartbeat from #{n}"
+        end
         Cluster.Strategy.connect_nodes(state.topology, connect, list_nodes, [n])
         :ok
       _ ->

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -6,6 +6,7 @@ defmodule Cluster.LoggerTest do
   import ExUnit.CaptureLog
 
   alias Cluster.Logger
+  Application.put_env(:libcluster, :debug, true)
 
   for level <- [:debug, :info, :warn, :error] do
     describe "#{level}/2" do


### PR DESCRIPTION
This PR brings a `debug :: boolean` application option, that can be set and unset at runtime, to allow temporary log without having to shutdown the node in order to recompile the configuration.

All the tests seem to be green on my machine and I have tested the feature manually.

@bitwalker Anything I might forget?