### PR TITLE
App refactoring fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # libcluster
 
 [![Hex.pm Version](http://img.shields.io/hexpm/v/libcluster.svg?style=flat)](https://hex.pm/packages/libcluster)
+[![Build Status](https://travis-ci.org/bitwalker/libcluster.svg?branch=master)](https://travis-ci.org/bitwalker/libcluster)
 
 This library provides a mechanism for automatically forming clusters of Erlang nodes, with
 either static or dynamic node membership. It provides a publish/subscribe mechanism for cluster

--- a/lib/app.ex
+++ b/lib/app.ex
@@ -23,7 +23,7 @@ defmodule Cluster.App do
     worker_args = [{:topology, topology} | extract_args(spec)]
     opts = Keyword.get(spec, :child_spec, [])
 
-    Supervisor.start_child(Cluster.Supervisor, worker(strategy, worker_args, opts))
+    Supervisor.start_child(Cluster.Supervisor, worker(strategy, [worker_args], opts))
   end
 
   defp get_child_specs() do
@@ -35,7 +35,7 @@ defmodule Cluster.App do
       worker_args = [{:topology, topology} | extract_args(spec)]
       opts = Keyword.get(spec, :child_spec, [])
 
-      worker(strategy, worker_args, opts)
+      worker(strategy, [worker_args], opts)
     end
   end
 


### PR DESCRIPTION
Tests were failing:
```
** (Mix) Could not start application libcluster: Cluster.App.start(:normal, []) returned an error: shutdown: failed to start child: Cluster.Strategy.Epmd
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Cluster.Strategy.Epmd.start_link/5 is undefined or private.
```
a small fix for that [![Build Status](https://travis-ci.org/flowerett/libcluster.svg?branch=fixes)](https://travis-ci.org/flowerett/libcluster)

Also, the Travis repo is not activated: https://travis-ci.org/bitwalker/libcluster
I've added a badge.