### PR TITLE
Fix docs of kubernetes strategy

### DIFF
--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -20,7 +20,7 @@ defmodule Cluster.Strategy.Kubernetes do
   `<ip-with-dashes>.<namespace>.pod.cluster.local`, e.g
   1-2-3-4.default.pod.cluster.local.
 
-  Getting `:ip` to work requires a bit fiddling in the container's CMD, for example:
+  Getting `:dns` to work requires a bit fiddling in the container's CMD, for example:
 
   ```yaml
   # deployment.yaml


### PR DESCRIPTION
We only need to build the FQDN in the vm.args if using mode :dns and not mode :ip as the docs mentions until this PR