### PR TITLE
Update DNS Poll Strategy

### DIFF
--- a/test/dns_poll_test.exs
+++ b/test/dns_poll_test.exs
@@ -72,4 +72,44 @@ defmodule Cluster.Strategy.DNSPollTest do
       refute_receive {:connect, _}, 100
     end)
   end
+
+  test "does not connect to anything with missing config params" do
+    capture_log(fn ->
+      [
+        topology: :dns_poll,
+        config: [
+          polling_interval: 100,
+          resolver: fn _query -> [{10, 0, 0, 1}] end
+        ],
+        connect: {Nodes, :connect, [self()]},
+        disconnect: {Nodes, :disconnect, [self()]},
+        list_nodes: {Nodes, :list_nodes, [[]]}
+      ]
+      |> DNSPoll.start_link()
+
+      refute_receive {:disconnect, _}, 100
+      refute_receive {:connect, _}, 100
+    end)
+  end
+
+  test "does not connect to anything with invalid config params" do
+    capture_log(fn ->
+      [
+        topology: :dns_poll,
+        config: [
+          query: :app,
+          node_basename: "",
+          polling_interval: 100,
+          resolver: fn _query -> [{10, 0, 0, 1}] end
+        ],
+        connect: {Nodes, :connect, [self()]},
+        disconnect: {Nodes, :disconnect, [self()]},
+        list_nodes: {Nodes, :list_nodes, [[]]}
+      ]
+      |> DNSPoll.start_link()
+
+      refute_receive {:disconnect, _}, 100
+      refute_receive {:connect, _}, 100
+    end)
+  end
 end

--- a/test/dns_poll_test.exs
+++ b/test/dns_poll_test.exs
@@ -1,0 +1,75 @@
+defmodule Cluster.Strategy.DNSPollTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+
+  alias Cluster.Nodes
+  alias Cluster.Strategy.DNSPoll
+
+  describe "start_link/1" do
+    test "adds new nodes" do
+      capture_log(fn ->
+        [
+          topology: :dns_poll,
+          config: [
+            polling_interval: 100,
+            query: "app",
+            node_basename: "node",
+            resolver: fn _query -> [{10, 0, 0, 1}, {10, 0, 0, 2}] end
+          ],
+          connect: {Nodes, :connect, [self()]},
+          disconnect: {Nodes, :disconnect, [self()]},
+          list_nodes: {Nodes, :list_nodes, [[]]}
+        ]
+        |> DNSPoll.start_link()
+
+        assert_receive {:connect, :"node@10.0.0.1"}, 100
+        assert_receive {:connect, :"node@10.0.0.2"}, 100
+      end)
+    end
+  end
+
+  test "removes nodes" do
+    capture_log(fn ->
+      [
+        topology: :dns_poll,
+        config: [
+          polling_interval: 100,
+          query: "app",
+          node_basename: "node",
+          resolver: fn _query -> [{10, 0, 0, 1}] end
+        ],
+        connect: {Nodes, :connect, [self()]},
+        disconnect: {Nodes, :disconnect, [self()]},
+        list_nodes: {Nodes, :list_nodes, [[:"node@10.0.0.1", :"node@10.0.0.2"]]},
+        meta: MapSet.new([:"node@10.0.0.1", :"node@10.0.0.2"])
+      ]
+      |> DNSPoll.start_link()
+
+      assert_receive {:disconnect, :"node@10.0.0.2"}, 100
+    end)
+  end
+
+  test "keeps state" do
+    capture_log(fn ->
+      [
+        topology: :dns_poll,
+        config: [
+          polling_interval: 100,
+          query: "app",
+          node_basename: "node",
+          resolver: fn _query -> [{10, 0, 0, 1}] end
+        ],
+        connect: {Nodes, :connect, [self()]},
+        disconnect: {Nodes, :disconnect, [self()]},
+        list_nodes: {Nodes, :list_nodes, [[:"node@10.0.0.1"]]},
+        meta: MapSet.new([:"node@10.0.0.1"])
+      ]
+      |> DNSPoll.start_link()
+
+      refute_receive {:disconnect, _}, 100
+      refute_receive {:connect, _}, 100
+    end)
+  end
+end


### PR DESCRIPTION
Hey @bitwalker,
during my work on the Rancher strategy #52, I found that it's hard to use it locally in development environments. I was looking for the solution and it turned out that Rancher has Internal DNS Service:
https://rancher.com/docs/rancher/v1.3/en/cattle/internal-dns-service/


> All services in the stack are resolvable by <service_name> and there is no need to set a service link between the services. For any services that are in a different stack, you’d resolve by <service_name>.<stack_name> instead of just <service_name>.

```
$ ping bar.stackb
PING bar.stackb (10.42.x.x) 56(84) bytes of data.
64 bytes from 10.42.x.x: icmp_seq=1 ttl=62 time=1.43 ms
64 bytes from 10.42.x.x: icmp_seq=2 ttl=62 time=1.15 ms
64 bytes from 10.42.x.x: icmp_seq=3 ttl=62 time=1.27 ms
```


So I tried to use this feature with the **DNSPoll** Strategy and it works well with both dev and prod for us now, all you need to do is just specify different **query** in configs:

config/dev.exs
```elixir
config :libcluster,
  topologies: [
    dns_poll_example: [
      strategy: Cluster.Strategy.DNSPoll,
      config: [
        query: "user",
        node_sname: "my-app"]]]

```

config/prod.exs:
```elixir
config :libcluster,
  topologies: [
    dns_poll_example: [
      strategy: Cluster.Strategy.DNSPoll,
      config: [
        query: "api.user",
        node_sname: "my-app"]]]
```

====
This PR is just a fix for current DNSPoll strategy as it's not really working.
The issue is inside the **do_poll** here: https://github.com/flowerett/libcluster/blob/master/lib/strategy/dns_poll.ex#L62
The *meta* tuple in the pattern matching for this method expects only free elements.

Here, after resolving new nodes it pushes a fourth element into it, so the strategy crashes:
https://github.com/flowerett/libcluster/blob/master/lib/strategy/dns_poll.ex#L84

I fixed that and refactored the strategy and it now works similar to others - holds info like **poll_interval**, **query** in the config and pushes updated nodelist to the **meta**.
Also, it now covered by tests.
 
As for the **Rancher** strategy not sure should we keep it in the **libcluster** or not. Will wait for your decision and then update the README accordingly.
