### PR TITLE
Fixing DNS strategy crash

### DIFF
--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -71,6 +71,7 @@ defmodule Cluster.Strategy.DNSPoll do
       query
       |> String.to_charlist()
       |> :inet_res.lookup(:in, :a)
+      |> Enum.map(&:inet_parse.ntoa(&1))
       |> Enum.map(&format_node(&1, node_sname))
       |> Enum.reject(fn n -> n == me end)
 
@@ -81,9 +82,10 @@ defmodule Cluster.Strategy.DNSPoll do
     # reschedule a call to itself in poll_interval ms
     Process.send_after(self(), :poll, poll_interval)
 
-    %{state | meta: {poll_interval, query, node_sname, nodes}}
+    state
   end
 
   # turn an ip into a node name atom, assuming that all other node names looks similar to our own name
-  defp format_node({a, b, c, d}, sname), do: :"#{sname}@#{a}.#{b}.#{c}.#{d}"
+
+  defp format_node(address, sname) when is_binary(address) , do: :"#{sname}@#{address}"
 end


### PR DESCRIPTION
* Fixing `"no function clause"` for `Cluster.Strategy.DNSPoll.do_poll` by making sure nodes are not added to `state.meta` since they don't seem to be used at all. 
Got: `meta: {5000, "my-app.example.com", "my-app", []}`
Expected: `meta: {5000, "my-app.example.com", "my-app"}`

* Using `:inet_parse.ntoa/1` to map `ip_address()` to string()` instead of hardcoding IPv4 values.

I've noticed it's very similar to the K8 DNS strategy, differences being ( I assume) it's using some older way of managing the nodes compared to the other strategies and it's using `:inet_res.lookup(address, :in, :a)` vs `:inet_res.getbyname(address, :a)` <- could you explain the difference between those? I'm not so well versed in DNS stuff generally. 


