### PR TITLE
Add optional encryption into gossip protocol

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -12,8 +12,13 @@ defmodule Cluster.Strategy.Gossip do
 
   By default, the gossip occurs on port 45892, using the multicast address 230.1.1.251
 
+  The gossip protocol is not encrypted by default, but can be by providing a secret
+  in the configuration of the strategy (as shown below).
+  This can also be used to run multiple clusters with the same multicast configuration,
+  as nodes not sharing the same encryption key will not be connected.
+
   You may configure the multicast address, the interface address to bind to, the port,
-  and the TTL of the packets, using the following settings:
+  the TTL of the packets and the optional secret using the following settings:
 
       config :libcluster,
         topologies: [
@@ -23,7 +28,8 @@ defmodule Cluster.Strategy.Gossip do
               port: 45892,
               if_addr: "0.0.0.0",
               multicast_addr: "230.1.1.251",
-              multicast_ttl: 1]]]
+              multicast_ttl: 1,
+              secret: "somepassword"]]]
 
   A TTL of 1 will limit packets to the local network, and is the default TTL.
 
@@ -77,7 +83,8 @@ defmodule Cluster.Strategy.Gossip do
         add_membership: {multicast_addr, {0, 0, 0, 0}}
       ])
 
-    state = %State{state | :meta => {multicast_addr, port, socket}}
+    secret = Keyword.get(config, :secret, nil)
+    state = %State{state | :meta => {multicast_addr, port, socket, secret}}
     {:ok, state, 0}
   end
 
@@ -95,27 +102,58 @@ defmodule Cluster.Strategy.Gossip do
   # Send stuttered heartbeats
   def handle_info(:timeout, state), do: handle_info(:heartbeat, state)
 
-  def handle_info(:heartbeat, %State{meta: {multicast_addr, port, socket}} = state) do
+  def handle_info(:heartbeat, %State{meta: {multicast_addr, port, socket, _}} = state) do
     debug(state.topology, "heartbeat")
-    :gen_udp.send(socket, multicast_addr, port, heartbeat(node()))
+    :gen_udp.send(socket, multicast_addr, port, heartbeat(node(), state))
     Process.send_after(self(), :heartbeat, :rand.uniform(5_000))
     {:noreply, state}
   end
 
   # Handle received heartbeats
-  def handle_info({:udp, _socket, _ip, _port, packet}, state) do
+  def handle_info(
+        {:udp, _socket, _ip, _port, <<"heartbeat::", _::binary>> = packet},
+        %State{meta: {_, _, _, secret}} = state
+      )
+      when is_nil(secret) do
     handle_heartbeat(state, packet)
     {:noreply, state}
   end
 
-  def terminate(_type, _reason, %State{meta: {_, _, socket}}) do
+  def handle_info(
+        {:udp, _socket, _ip, _port, <<iv::binary-size(16)>> <> ciphertext},
+        %State{meta: {_, _, _, secret}} = state
+      )
+      when is_binary(secret) do
+    case decrypt(ciphertext, secret, iv) do
+      {:ok, plaintext} ->
+        handle_heartbeat(state, plaintext)
+        {:noreply, state}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:udp, _socket, _ip, _port, _}, state) do
+    {:noreply, state}
+  end
+
+  def terminate(_type, _reason, %State{meta: {_, _, socket, _}}) do
     :gen_udp.close(socket)
     :ok
   end
 
   # Construct iodata representing packet to send
-  defp heartbeat(node_name) do
+  defp heartbeat(node_name, %State{meta: {_, _, _, secret}})
+       when is_nil(secret) do
     ["heartbeat::", :erlang.term_to_binary(%{node: node_name})]
+  end
+
+  defp heartbeat(node_name, %State{meta: {_, _, _, secret}}) when is_binary(secret) do
+    message = "heartbeat::" <> :erlang.term_to_binary(%{node: node_name})
+    {:ok, iv, msg} = encrypt(message, secret)
+
+    [iv, msg]
   end
 
   # Upon receipt of a heartbeat, we check to see if the node
@@ -145,5 +183,73 @@ defmodule Cluster.Strategy.Gossip do
 
   defp handle_heartbeat(_state, _packet) do
     :ok
+  end
+
+  defp encrypt(plaintext, password) do
+    iv = :crypto.strong_rand_bytes(16)
+    key = :crypto.hash(:sha256, password)
+    ciphertext = :crypto.block_encrypt(:aes_cbc256, key, iv, pkcs7_pad(plaintext))
+
+    {:ok, iv, ciphertext}
+  end
+
+  defp decrypt(ciphertext, password, iv) do
+    key = :crypto.hash(:sha256, password)
+
+    with {:unpadding, {:ok, padded}} <- {:unpadding, safe_decrypt(key, iv, ciphertext)},
+         {:decrypt, {:ok, _plaintext} = res} <- {:decrypt, pkcs7_unpad(padded)} do
+      res
+    else
+      {:unpadding, :error} -> {:error, :decrypt}
+      {:decrypt, :error} -> {:error, :unpadding}
+    end
+  end
+
+  defp safe_decrypt(key, iv, ciphertext) do
+    try do
+      {:ok, :crypto.block_decrypt(:aes_cbc256, key, iv, ciphertext)}
+    rescue
+      ArgumentError ->
+        :error
+    end
+  end
+
+  #
+  # Pads a message using the PKCS #7 cryptographic message syntax.
+  #
+  # from: https://github.com/izelnakri/aes256/blob/master/lib/aes256.ex
+  #
+  # See: https://tools.ietf.org/html/rfc2315
+  # See: `pkcs7_unpad/1`
+  defp pkcs7_pad(message) do
+    bytes_remaining = rem(byte_size(message), 16)
+    padding_size = 16 - bytes_remaining
+    message <> :binary.copy(<<padding_size>>, padding_size)
+  end
+
+  #
+  # Unpads a message using the PKCS #7 cryptographic message syntax.
+  #
+  # from: https://github.com/izelnakri/aes256/blob/master/lib/aes256.ex
+  #
+  # See: https://tools.ietf.org/html/rfc2315
+  # See: `pkcs7_pad/1`
+  defp pkcs7_unpad(<<>>), do: :error
+
+  defp pkcs7_unpad(message) do
+    padding_size = :binary.last(message)
+
+    if padding_size <= 16 do
+      message_size = byte_size(message)
+
+      if binary_part(message, message_size, -padding_size) ===
+           :binary.copy(<<padding_size>>, padding_size) do
+        {:ok, binary_part(message, 0, message_size - padding_size)}
+      else
+        :error
+      end
+    else
+      :error
+    end
   end
 end


### PR DESCRIPTION
With this PR is possible to add and optional encryption to the gossip protocol, for enhanced security and privacy.
Also  permits different cluster to exists on same mcast addr/port by just changing encryption password.

The patch is fully backward compatible.

A couple of padding functions are taken (and credit given)  https://github.com/izelnakri/aes256 , in order to avoid importing a new dep for just using the padding helpers.

Any feedback is appreciated :) and I hope is useful.