### PR TITLE
Fixed the logger to be compatible with Logger's compile time purging

### DIFF
--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -8,13 +8,16 @@ defmodule Cluster.Logger do
         :ok
 
       _ ->
-        log(:debug, t, msg)
+        Logger.debug(log_message(t, msg))
     end
   end
 
-  def info(t, msg), do: log(:info, t, msg)
-  def warn(t, msg), do: log(:warn, t, msg)
-  def error(t, msg), do: log(:error, t, msg)
+  def info(t, msg), do: Logger.info(log_message(t, msg))
+  def warn(t, msg), do: Logger.warn(log_message(t, msg))
+  def error(t, msg), do: Logger.error(log_message(t, msg))
 
-  defp log(level, t, msg), do: Logger.log(level, "[libcluster:#{t}] #{msg}")
+  @compile {:inline, log_message: 2}
+  defp log_message(t, msg) do
+    "[libcluster:#{t}] #{msg}"
+  end
 end


### PR DESCRIPTION
Hi there!

First of all, thanks for this and many other awesome libraries!

We've been using libcluster in development and production for a while now, but one thing that was bugging me is that I could not purge logs just from libcluster using the [Logger configuration](https://hexdocs.pm/logger/Logger.html#module-application-configuration).

In our case, we needed this because libcluster was issuing some warn logs in `MIX_ENV=dev` that were making the usage of iex almost imposible, and we couldn't just disable all the logs nor disable libcluster itself, because we needed it in order to use clustering in our local docker containers.

It turns out Logger can only purge logs when it's level macros are being called directly (`Logger.warn`, `Logger.info` and so on) or when it's `Logger.log` macro is called with a compile-time atom. Inspecting the code for `Cluster.Logger` I found out that `Logger.log` was being called with a dynamic variable, which was preventing the compile time purging.

Anyways, just a small fix ^^

Thanks again for all your awesome work in this comunity, your libs saved me and my team a ton of time and headaches :heart: 