### PR TITLE
allow to create cluster from nodes from different namespaces in kubernetes strategy

### DIFF
--- a/test/fixtures/vcr_cassettes/kubernetes.json
+++ b/test/fixtures/vcr_cassettes/kubernetes.json
@@ -30,5 +30,37 @@
       ],
       "type": "ok"
     }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "***"
+      },
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": {
+          "ssl": "[verify: :verify_none]"
+        }
+      },
+      "request_body": "",
+      "url": "https://cluster.localhost/api/v1/namespaces/airatel-service-test/endpoints?labelSelector=app=test_selector"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"apiVersion\":\"v1\",\"items\":[{\"metadata\":{\"creationTimestamp\":\"2018-01-26T12:29:03Z\",\"labels\":{\"app\":\"development\",\"chart\":\"CHART_PLACEHOLDER\"},\"name\":\"development-development\",\"namespace\":\"airatel-service-test\",\"resourceVersion\":\"17037787\",\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"uid\":\"7e3faf1e-0294-11e8-bcad-42010a9c01cc\"},\"subsets\":[{\"addresses\":[{\"ip\":\"10.48.33.134\",\"nodeName\":\"gke-jshmrtn-cluster-default-pool-a61da41f-db9x\",\"targetRef\":{\"kind\":\"Pod\",\"name\":\"development-4292695165-mgq9a\",\"namespace\":\"airatel-service-test\",\"resourceVersion\":\"17037783\",\"uid\":\"eb0f3e80-0295-11e8-bcad-42010a9c01cd\"}}],\"ports\":[{\"name\":\"web\",\"port\":8443,\"protocol\":\"TCP\"}]}]}],\"kind\":\"EndpointsList\",\"metadata\":{\"resourceVersion\":\"17042410\",\"selfLink\":\"SELFLINK_PLACEHOLDER\"}}",
+      "headers": {
+        "date": "Fri, 26 Jan 2018 13:18:46 GMT",
+        "content-length": "877",
+        "content-type": "application/json"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok"
+    }
   }
 ]

--- a/test/kubernetes_test.exs
+++ b/test/kubernetes_test.exs
@@ -32,20 +32,49 @@ defmodule Cluster.Strategy.KubernetesTest do
       use_cassette "kubernetes", custom: true do
         capture_log(fn ->
           start_supervised!({Kubernetes,
-           [%Cluster.Strategy.State{
-             topology: :name,
-             config: [
-               kubernetes_node_basename: "test_basename",
-               kubernetes_selector: "app=test_selector",
-               # If you want to run the test freshly, you'll need to create a DNS Entry
-               kubernetes_master: "cluster.localhost",
-               kubernetes_service_account_path:
-                 Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
-             ],
-             connect: {Nodes, :connect, [self()]},
-             disconnect: {Nodes, :disconnect, [self()]},
-             list_nodes: {Nodes, :list_nodes, [[]]},
-           }]})
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_selector: "app=test_selector",
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost",
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
+
+          assert_receive {:connect, _}, 5_000
+        end)
+      end
+    end
+
+    test "connect nodes from different namespaces" do
+      use_cassette "kubernetes", custom: true do
+        capture_log(fn ->
+          start_supervised!({Kubernetes,
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_selector: "app=test_selector",
+                 kubernetes_namespace: "airatel-service-test",
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost",
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
 
           assert_receive {:connect, _}, 5_000
         end)
@@ -56,24 +85,28 @@ defmodule Cluster.Strategy.KubernetesTest do
       use_cassette "kubernetes", custom: true do
         capture_log(fn ->
           start_supervised!({Kubernetes,
-           [%Cluster.Strategy.State{
-             topology: :name,
-             config: [
-               kubernetes_node_basename: "test_basename",
-               kubernetes_cluster_name: "my_cluster",
-               mode: :dns,
-               kubernetes_selector: "app=test_selector",
-               # If you want to run the test freshly, you'll need to create a DNS Entry
-               kubernetes_master: "cluster.localhost",
-               kubernetes_service_account_path:
-                 Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
-             ],
-             connect: {Nodes, :connect, [self()]},
-             disconnect: {Nodes, :disconnect, [self()]},
-             list_nodes: {Nodes, :list_nodes, [[]]},
-           }]})
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_cluster_name: "my_cluster",
+                 mode: :dns,
+                 kubernetes_selector: "app=test_selector",
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost",
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
 
-          assert_receive {:connect, :"test_basename@10-48-33-136.airatel-service-localization.pod.my_cluster.local"}, 5_000
+          assert_receive {:connect,
+                          :"test_basename@10-48-33-136.airatel-service-localization.pod.my_cluster.local"},
+                         5_000
         end)
       end
     end
@@ -82,21 +115,23 @@ defmodule Cluster.Strategy.KubernetesTest do
       use_cassette "kubernetes_pods", custom: true do
         capture_log(fn ->
           start_supervised!({Kubernetes,
-           [%Cluster.Strategy.State{
-             topology: :name,
-             config: [
-               kubernetes_node_basename: "test_basename",
-               kubernetes_selector: "app=test_selector",
-               # If you want to run the test freshly, you'll need to create a DNS Entry
-               kubernetes_master: "cluster.localhost",
-               kubernetes_ip_lookup_mode: :pods,
-               kubernetes_service_account_path:
-                 Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
-             ],
-             connect: {Nodes, :connect, [self()]},
-             disconnect: {Nodes, :disconnect, [self()]},
-             list_nodes: {Nodes, :list_nodes, [[]]},
-           }]})
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_selector: "app=test_selector",
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost",
+                 kubernetes_ip_lookup_mode: :pods,
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
 
           assert_receive {:connect, :"test_basename@10.48.33.136"}, 5_000
         end)
@@ -107,24 +142,28 @@ defmodule Cluster.Strategy.KubernetesTest do
       use_cassette "kubernetes_pods", custom: true do
         capture_log(fn ->
           start_supervised!({Kubernetes,
-           [%Cluster.Strategy.State{
-             topology: :name,
-             config: [
-               kubernetes_node_basename: "test_basename",
-               kubernetes_selector: "app=test_selector",
-               # If you want to run the test freshly, you'll need to create a DNS Entry
-               kubernetes_master: "cluster.localhost",
-               kubernetes_ip_lookup_mode: :pods,
-               mode: :dns,
-               kubernetes_service_account_path:
-                 Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
-             ],
-             connect: {Nodes, :connect, [self()]},
-             disconnect: {Nodes, :disconnect, [self()]},
-             list_nodes: {Nodes, :list_nodes, [[]]},
-           }]})
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_selector: "app=test_selector",
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost",
+                 kubernetes_ip_lookup_mode: :pods,
+                 mode: :dns,
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
 
-          assert_receive {:connect, :"test_basename@10-48-33-136.airatel-service-localization.pod.cluster.local"}, 5_000
+          assert_receive {:connect,
+                          :"test_basename@10-48-33-136.airatel-service-localization.pod.cluster.local"},
+                         5_000
         end)
       end
     end


### PR DESCRIPTION
Right now, cluster will can be created between nodes from the same namespace which is defined from `Path.join(service_account_path, "namespace")`. I've added `kubernetes_namespace` parameter which allows to set namespace directly and that way, connect nodes from different kubernetes namespaces into cluster.