### PR TITLE
Ensure module is loaded before checking `function_exported?`

### DIFF
--- a/lib/strategy/strategy.ex
+++ b/lib/strategy/strategy.ex
@@ -152,7 +152,7 @@ defmodule Cluster.Strategy do
   end
 
   defp ensure_exported!(mod, fun, arity) do
-    unless function_exported?(mod, fun, arity) do
+    unless Code.ensure_loaded?(mod) and function_exported?(mod, fun, arity) do
       raise "#{mod}.#{fun}/#{arity} is undefined!"
     end
   end


### PR DESCRIPTION
`function_exported?/3` will return false if the module is not loaded, even if a particular function is exported. So we need to first ensure the module is loaded before calling  `function_exported?`