### PR TITLE
fix adding node after container restart

### DIFF
--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -104,11 +104,12 @@ defmodule Cluster.Strategy.Kubernetes do
 
   defp load(%State{topology: topology, meta: meta} = state) do
     new_nodelist = MapSet.new(get_nodes(state))
+    nodes = Node.list()
 
     added =
       MapSet.union(
         MapSet.difference(new_nodelist, meta),
-        MapSet.new(Enum.filter(new_nodelist, &(&1 not in Node.list())))
+        MapSet.new(Enum.filter(new_nodelist, &(&1 not in nodes)))
       )
 
     removed = MapSet.difference(state.meta, new_nodelist)

--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -104,7 +104,13 @@ defmodule Cluster.Strategy.Kubernetes do
 
   defp load(%State{topology: topology, meta: meta} = state) do
     new_nodelist = MapSet.new(get_nodes(state))
-    added = MapSet.difference(new_nodelist, meta)
+
+    added =
+      MapSet.union(
+        MapSet.difference(new_nodelist, meta),
+        MapSet.new(Enum.filter(new_nodelist, &(&1 not in Node.list())))
+      )
+
     removed = MapSet.difference(state.meta, new_nodelist)
 
     new_nodelist =


### PR DESCRIPTION
Issue:

Node will not be added to the cluster if k8s restarted container inside pod faster than libcluster get the difference.
