### PR TITLE
Optional Gossip support for broadcasting only

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -37,6 +37,18 @@ defmodule Cluster.Strategy.Gossip do
   only uses broadcasting. This limits connectivity to local network but works on in
   scenarios where multicast is not enabled. Use `multicast_addr` as the broadcast address.
 
+  Example for broadcast only:
+
+      config :libcluster,
+        topologies: [
+          gossip_example: [
+            strategy: #{__MODULE__},
+            config: [
+              port: 45892,
+              if_addr: "0.0.0.0",
+              multicast_addr: "255.255.255.255",
+              broadcast_only: true]]]
+
   Debug logging is deactivated by default for this clustering strategy, but it can be easily activated by configuring the application:
 
       use Mix.Config

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -92,13 +92,15 @@ defmodule Cluster.Strategy.Gossip do
       |> sanitize_ip()
 
     multicast_opts =
-      unless broadcast_only? == true do
-        [
-          multicast_ttl: ttl,
-          multicast_loop: true
-        ]
-      else
-        []
+      cond do
+        broadcast_only? ->
+          []
+        
+        :else ->
+          [
+            multicast_ttl: ttl,
+            multicast_loop: true
+          ]
       end
 
     options =

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -33,6 +33,10 @@ defmodule Cluster.Strategy.Gossip do
 
   A TTL of 1 will limit packets to the local network, and is the default TTL.
 
+  Optionally, `broadcast_only: true` option can be set which disables multicast and
+  only uses broadcasting. This limits connectivity to local network but works on in
+  scenarios where multicast is not enabled. Use `multicast_addr` as the broadcast address.
+
   Debug logging is deactivated by default for this clustering strategy, but it can be easily activated by configuring the application:
 
       use Mix.Config


### PR DESCRIPTION
Suggested changes to support pure broadcasting (sans multicast) support in the Gossip module. This can be useful for local area networks which don't properly support multicast/IGMP, as is the case with some home routers. 

Our company uses Elixir for embedded sensors. Some network interfaces don't appear to properly support multicast, which means the Gossip module doesn't work in these environments We have our own module, but think other might find the ability to do broadcast only useful. 
