### PR TITLE
strategy: gossip: add a way to change the multicast output interface

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -87,6 +87,8 @@ defmodule Cluster.Strategy.Gossip do
     broadcast_only? = Keyword.get(config, :broadcast_only, false)
     ttl = Keyword.get(config, :multicast_ttl, 1)
 
+    multicast_if = Keyword.get(config, :multicast_if)
+    
     multicast_addr =
       config
       |> Keyword.get(:multicast_addr, @default_multicast_addr)

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -101,7 +101,7 @@ defmodule Cluster.Strategy.Gossip do
           
         multicast_if != nil ->
           [
-            multicast_if: sanitize_ip(multicast_if)
+            multicast_if: sanitize_ip(multicast_if),
             multicast_ttl: ttl,
             multicast_loop: true
           ]


### PR DESCRIPTION
This patch will allow user to set the interface that should be used to
send the multicast datagrams. This is helpful on systems that have more
than one interface and we want the source address of datagram to be
specific.