### PR TITLE
strategy: gossip: use handle_continue callback if possible

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -91,6 +91,7 @@ defmodule Cluster.Strategy.Gossip do
     secret = Keyword.get(config, :secret, nil)
     state = %State{state | :meta => {multicast_addr, port, socket, secret}}
 
+    # TODO: Remove this version check when we deprecate OTP < 21 support
     if :erlang.system_info(:otp_release) >= '21' do
       {:ok, state, {:continue, nil}}
     else
@@ -126,6 +127,7 @@ defmodule Cluster.Strategy.Gossip do
   end
 
   # Send stuttered heartbeats
+  # TODO: Remove this version check when we deprecate OTP < 21 support
   if :erlang.system_info(:otp_release) >= '21' do
     @impl true
     def handle_continue(_, state), do: handle_info(:heartbeat, state)

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -90,7 +90,12 @@ defmodule Cluster.Strategy.Gossip do
 
     secret = Keyword.get(config, :secret, nil)
     state = %State{state | :meta => {multicast_addr, port, socket, secret}}
-    {:ok, state, 0}
+
+    if :erlang.system_info(:otp_release) >= '21' do
+      {:ok, state, {:continue, nil}}
+    else
+      {:ok, state, 0}
+    end
   end
 
   defp reuse_port() do
@@ -121,8 +126,13 @@ defmodule Cluster.Strategy.Gossip do
   end
 
   # Send stuttered heartbeats
-  @impl true
-  def handle_info(:timeout, state), do: handle_info(:heartbeat, state)
+  if :erlang.system_info(:otp_release) >= '21' do
+    @impl true
+    def handle_continue(_, state), do: handle_info(:heartbeat, state)
+  else
+    @impl true
+    def handle_info(:timeout, state), do: handle_info(:heartbeat, state)
+  end
 
   def handle_info(:heartbeat, %State{meta: {multicast_addr, port, socket, _}} = state) do
     debug(state.topology, "heartbeat")


### PR DESCRIPTION
Since OTP version 21, we can make sure that we will start the heartbeat
sending using the handle_continue callback.
If given OTP is older, the code will use the older (not reliable)
timeout method.