### PR TITLE
Fix Cluster.Strategy.Kubernetes documentation

### DIFF
--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -62,7 +62,7 @@ defmodule Cluster.Strategy.Kubernetes do
 
   In this case you must also set `kubernetes_service_name` to the name of the K8S service that is being queried.
 
-  `mode' defaults to `:ip`.
+  `mode` defaults to `:ip`.
 
   An example configuration is below:
 

--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -22,8 +22,8 @@ defmodule Cluster.Strategy.Kubernetes do
   `domain` would be the value configured in `mode` and can be either of type `:ip`
   (the pod's ip, can be obtained by setting an env variable to status.podIP), `:hostname`
   or `:dns`, which is the pod's internal A Record. This A Record has the format
-  `<ip-with-dashes>.<namespace>.pod.cluster.local`, e.g
-  1-2-3-4.default.pod.cluster.local.
+  `<ip-with-dashes>.<namespace>.pod.cluster.local`, e.g.
+  `1-2-3-4.default.pod.cluster.local`.
 
   Getting `:dns` to work requires setting the `POD_A_RECORD` environment variable before
   the application starts. If you use Distillery you can set it in your `pre_configure` hook:


### PR DESCRIPTION
The formatting in the documentation was broken because a ` was mistyped as '