### PR TITLE
Add :namespace to Kubernetes.DNSSRV example configuration documentation

### DIFF
--- a/lib/strategy/kubernetes_dns_srv.ex
+++ b/lib/strategy/kubernetes_dns_srv.ex
@@ -18,6 +18,7 @@ defmodule Cluster.Strategy.Kubernetes.DNSSRV do
           k8s_example: [
             strategy: #{__MODULE__},
             config: [
+              namespace: "elixir-plug-poc",
               service: "elixir-plug-poc",
               application_name: "elixir_plug_poc",
               polling_interval: 10_000]]]


### PR DESCRIPTION
Add `:namespace` to `Cluster.Strategry.Kubernetes.DNSSRV` example configuration documentation.

`namespace` is a required config key. See `namespace = Keyword.fetch!(config, :namespace)` here https://github.com/bitwalker/libcluster/blob/616c11510e83911f1a3780b58c8dd69f42a63c09/lib/strategy/kubernetes_dns_srv.ex#L189