### PR TITLE
Use handle_continue to avoid blocking during startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,16 @@
 sudo: false
 language: elixir
 elixir:
-  - 1.6
-  - 1.7
   - 1.8
   - 1.9
 otp_release:
-  - 20.3
   - 21.3
   - 22.1
-
-matrix:
-  exclude:
-  - otp_release: 22.1
-    elixir: 1.6
 
 script:
   - "mix format --check-formatted --dry-run"
   - "MIX_ENV=test mix do deps.get, test"
+
 notifications:
   recipients:
     - paulschoenfelder@gmail.com

--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -38,7 +38,12 @@ defmodule Cluster.Strategy.DNSPoll do
   end
 
   def init([%State{} = state]) do
-    {:ok, do_poll(state)}
+    {:ok, state, {:continue, :poll}}
+  end
+
+  @impl true
+  def handle_continue(:poll, state) do
+    {:noreply, do_poll(state)}
   end
 
   @impl true

--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -96,7 +96,12 @@ defmodule Cluster.Strategy.Kubernetes do
   end
 
   def init([%State{} = state]) do
-    {:ok, load(state)}
+    {:ok, state, {:continue, :load}}
+  end
+
+  @impl true
+  def handle_continue(:load, state) do
+    {:noreply, load(state)}
   end
 
   @impl true

--- a/lib/strategy/kubernetes_dns.ex
+++ b/lib/strategy/kubernetes_dns.ex
@@ -40,7 +40,12 @@ defmodule Cluster.Strategy.Kubernetes.DNS do
   end
 
   def init([%State{} = state]) do
-    {:ok, load(state), 0}
+    {:ok, state, {:continue, :load}}
+  end
+
+  @impl true
+  def handle_continue(:load, state) do
+    {:noreply, load(state), 0}
   end
 
   @impl true

--- a/lib/strategy/kubernetes_dns_srv.ex
+++ b/lib/strategy/kubernetes_dns_srv.ex
@@ -118,7 +118,12 @@ defmodule Cluster.Strategy.Kubernetes.DNSSRV do
   end
 
   def init([%State{} = state]) do
-    {:ok, load(state), 0}
+    {:ok, state, {:continue, :load}}
+  end
+
+  @impl true
+  def handle_continue(:load, state) do
+    {:noreply, load(state), 0}
   end
 
   @impl true

--- a/lib/strategy/rancher.ex
+++ b/lib/strategy/rancher.ex
@@ -55,7 +55,12 @@ defmodule Cluster.Strategy.Rancher do
   end
 
   def init([%State{} = state]) do
-    {:ok, load(state)}
+    {:ok, state, {:continue, :load}}
+  end
+
+  @impl true
+  def handle_continue(:load, state) do
+    {:noreply, load(state)}
   end
 
   @impl true


### PR DESCRIPTION
Hi!

We've been seeing some issues where libcluster sometimes delays the start of our application (causing automated healthchecks from Kubernetes to fail) which throws us into a restart-loop.

This moves the initialization from `init` to the new `handle_continue` callback introduced in OTP21.