### PR TITLE
fix formatting in Kubernetes docs

### DIFF
--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -62,7 +62,7 @@ defmodule Cluster.Strategy.Kubernetes do
 
   In this case you must also set `kubernetes_service_name` to the name of the K8S service that is being queried.
 
-  `mode' defaults to `:ip`.
+  `mode` defaults to `:ip`.
 
   An example configuration is below:
 


### PR DESCRIPTION
Before:
![libcluster-before](https://user-images.githubusercontent.com/7762396/71805640-0745c880-3067-11ea-865e-ab9d25009377.png)

After:
![libcluster-after](https://user-images.githubusercontent.com/7762396/71805653-0ad94f80-3067-11ea-8e66-afdc61272c3f.png)
