### PR TITLE
DNSPoll:  Reconnect to nodes we've lost a connection to.

### DIFF
--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -61,7 +61,7 @@ defmodule Cluster.Strategy.DNSPoll do
       |> MapSet.new()
 
     new_nodelist = state |> get_nodes() |> MapSet.new()
-    removed = state.meta |> MapSet.difference(new_nodelist)
+    removed = MapSet.difference(state.meta, new_nodelist)
 
     # Nodes still mentioned in dns which we used to be connected to
     disconnected_nodes = state.meta |> MapSet.difference(nodes) |> MapSet.difference(removed)

--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -54,9 +54,14 @@ defmodule Cluster.Strategy.DNSPoll do
            list_nodes: list_nodes
          } = state
        ) do
+
+    nodes = Node.list() |> MapSet.new
     new_nodelist = state |> get_nodes() |> MapSet.new()
-    added = MapSet.difference(new_nodelist, state.meta)
-    removed = MapSet.difference(state.meta, new_nodelist)
+    removed = state.meta |> MapSet.difference(new_nodelist)
+
+    # Nodes still mentioned in dns which we used to be connected to
+    disconnected_nodes = state.meta |> MapSet.difference(nodes) |> MapSet.difference(removed)
+    added = new_nodelist |> MapSet.difference(state.meta) |> MapSet.union(disconnected_nodes)
 
     new_nodelist =
       case Strategy.disconnect_nodes(

--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -54,12 +54,10 @@ defmodule Cluster.Strategy.DNSPoll do
            list_nodes: list_nodes
          } = state
        ) do
-    current_node = Node.self()
     {list_mod, list_fun, list_args} = list_nodes
 
     nodes =
       apply(list_mod, list_fun, list_args)
-      |> Enum.reject(fn n -> current_node == n end)
       |> MapSet.new()
 
     new_nodelist = state |> get_nodes() |> MapSet.new()

--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -54,8 +54,14 @@ defmodule Cluster.Strategy.DNSPoll do
            list_nodes: list_nodes
          } = state
        ) do
+    current_node = Node.self()
+    {list_mod, list_fun, list_args} = list_nodes
 
-    nodes = Node.list() |> MapSet.new
+    nodes =
+      apply(list_mod, list_fun, list_args)
+      |> Enum.reject(fn n -> current_node == n end)
+      |> MapSet.new()
+
     new_nodelist = state |> get_nodes() |> MapSet.new()
     removed = state.meta |> MapSet.difference(new_nodelist)
 


### PR DESCRIPTION
When using dns polling, if a node that is mentioned in DNS happens to die, or get disconnected somehow, even though we are continually polling and continually get an entry in dns for this node, if it comes back up at the same ip, we will never directly reconnect to it.

This says, for any node we used to be connected to that we appear not to be connected to anymore, and which is still mentioned in dns, reconnect to that.