### PR TITLE
Add 'LocalEpmd' clustering strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Clustering strategy for the Rancher container platform (see: https://github.com/rancher/rancher)
+- LocalEpmd strategy that uses epmd to discover nodes on the local host
 
 ## 2.0.0
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ each strategy is kept up to date with the module implementing it.
 
 ## Clustering
 
-You have a handful of choices with regards to cluster management out of the box: 
+You have a handful of choices with regards to cluster management out of the box:
 
-- `Cluster.Strategy.Epmd`, which relies on `epmd` to connect to a configured set of hosts.
+- `Cluster.Strategy.Epmd`, which relies on `epmd` to connect to a configured set
+  of hosts.
+- `Cluster.Strategy.LocalEpmd`, which relies on `epmd` to connect to discovered
+  nodes on the local host.
 - `Cluster.Strategy.ErlangHosts`, which uses the `.hosts.erlang` file to
   determine which hosts to connect to.
 - `Cluster.Strategy.Gossip`, which uses multicast UDP to form a cluster between

--- a/lib/strategy/local_epmd.ex
+++ b/lib/strategy/local_epmd.ex
@@ -1,0 +1,39 @@
+defmodule Cluster.Strategy.LocalEpmd do
+  @moduledoc """
+  This clustering strategy relies on Erlang's built-in distribution protocol.
+
+  Unlike Cluster.Strategy.Empd, this strategy assumes that all nodes are on
+  the local host and can be discovered by epmd.
+
+  It should be configured as follows:
+
+      config :libcluster,
+        topologies: [
+          local_epmd_example: [
+            strategy: #{__MODULE__}]]
+
+  """
+  use Cluster.Strategy
+
+  alias Cluster.Strategy.State
+
+  def start_link([%State{} = state]) do
+    nodes = discover_nodes()
+
+    Cluster.Strategy.connect_nodes(state.topology, state.connect, state.list_nodes, nodes)
+    :ignore
+  end
+
+  defp discover_nodes do
+    suffix = get_host_suffix(Node.self())
+
+    {:ok, names} = :erl_epmd.names()
+    for {n, _} <- names, do: List.to_atom(n ++ suffix)
+  end
+
+  defp get_host_suffix(self) do
+    self = Atom.to_charlist(self)
+    [_, suffix] = :string.split(self, '@')
+    '@' ++ suffix
+  end
+end


### PR DESCRIPTION
When testing on a single host, it's annoying to have to specify the node
names in the 'Epmd' configuration.

Add a 'LocalEpmd' clustering strategy that uses epmd to discover all
nodes on the local host.

Fixes #124