### PR TITLE
Strategy.Kubernetes: support pods ip_lookup_mode in hostname mode

### DIFF
--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -305,9 +305,10 @@ defmodule Cluster.Strategy.Kubernetes do
         Enum.map(items, fn
           %{
             "status" => %{"podIP" => ip},
-            "metadata" => %{"namespace" => ns}
+            "metadata" => %{"namespace" => ns},
+            "spec" => pod_spec
           } ->
-            %{ip: ip, namespace: ns}
+            %{ip: ip, namespace: ns, hostname: pod_spec["hostname"]}
 
           _ ->
             nil

--- a/test/fixtures/vcr_cassettes/kubernetes_pods.json
+++ b/test/fixtures/vcr_cassettes/kubernetes_pods.json
@@ -17,7 +17,7 @@
     },
     "response": {
       "binary": false,
-      "body": "{\"kind\":\"PodList\",\"apiVersion\":\"v1\",\"metadata\":{\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"resourceVersion\":\"17042410\"},\"items\":[{\"metadata\":{\"name\":\"development-development\",\"namespace\":\"airatel-service-localization\",\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"uid\":\"7e3faf1e-0294-11e8-bcad-42010a9c01cc\",\"resourceVersion\":\"17037787\",\"creationTimestamp\":\"2018-01-26T12:29:03Z\",\"labels\":{\"app\":\"development\",\"chart\":\"CHART_PLACEHOLDER\"}},\"status\":{\"podIP\": \"10.48.33.136\"}}]}\n",
+      "body": "{\"kind\":\"PodList\",\"apiVersion\":\"v1\",\"metadata\":{\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"resourceVersion\":\"17042410\"},\"items\":[{\"metadata\":{\"name\":\"development-development\",\"namespace\":\"airatel-service-localization\",\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"uid\":\"7e3faf1e-0294-11e8-bcad-42010a9c01cc\",\"resourceVersion\":\"17037787\",\"creationTimestamp\":\"2018-01-26T12:29:03Z\",\"labels\":{\"app\":\"development\",\"chart\":\"CHART_PLACEHOLDER\"}},\"spec\": { \"hostname\": \"my-hostname-0\" },\"status\":{\"podIP\": \"10.48.33.136\"}}]}\n",
       "headers": {
         "date": "Fri, 26 Jan 2018 13:18:46 GMT",
         "content-length": "877",

--- a/test/kubernetes_test.exs
+++ b/test/kubernetes_test.exs
@@ -142,6 +142,38 @@ defmodule Cluster.Strategy.KubernetesTest do
       end
     end
 
+    test "works with hostname and cluster_name in ip_lookup_mode: :pods" do
+      use_cassette "kubernetes_pods", custom: true do
+        capture_log(fn ->
+          start_supervised!({Kubernetes,
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_ip_lookup_mode: :pods,
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_cluster_name: "my_cluster",
+                 mode: :hostname,
+                 kubernetes_selector: "app=test_selector",
+                 kubernetes_service_name: "my_service",
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost",
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
+
+          assert_receive {:connect,
+                          :"test_basename@my-hostname-0.my_service.airatel-service-localization.svc.my_cluster.local"},
+                         5_000
+        end)
+      end
+    end
+
     test "works with pods" do
       use_cassette "kubernetes_pods", custom: true do
         capture_log(fn ->


### PR DESCRIPTION
Currently when `mode: :hostname` is being used with `ip_lookup_mode: :pods` an exception is raised:

```
(FunctionClauseError) no function clause matching in Cluster.Strategy.Kubernetes.format_node/5
```

This PR adds the support for hostname in `ip_lookup_mode: :pods` by including the `hostname` key in the `parse_response` map.