### PR TITLE
Kubernetes DNS SRV strategy doesn't reconnect

### DIFF
--- a/lib/strategy/kubernetes_dns_srv.ex
+++ b/lib/strategy/kubernetes_dns_srv.ex
@@ -136,7 +136,6 @@ defmodule Cluster.Strategy.Kubernetes.DNSSRV do
 
   defp load(%State{topology: topology, meta: meta} = state) do
     new_nodelist = MapSet.new(get_nodes(state))
-    added = MapSet.difference(new_nodelist, meta)
     removed = MapSet.difference(meta, new_nodelist)
 
     new_nodelist =
@@ -161,7 +160,7 @@ defmodule Cluster.Strategy.Kubernetes.DNSSRV do
              topology,
              state.connect,
              state.list_nodes,
-             MapSet.to_list(added)
+             MapSet.to_list(new_nodelist)
            ) do
         :ok ->
           new_nodelist


### PR DESCRIPTION
Kubernetes DNS SRV strategy also has the same problem: once a node disconnects, it never reconnects, except if it "bounces".