### PR TITLE
DNSPoll: resolve ipv6

### DIFF
--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -152,10 +152,10 @@ defmodule Cluster.Strategy.DNSPoll do
   end
 
   def lookup_all_ips(q) do
-    Enum.map([:a, :aaaa], fn t -> :inet_res.lookup(q, :in, t) end) |> List.flatten
+    Enum.flat_map([:a, :aaaa], fn t -> :inet_res.lookup(q, :in, t) end)
   end
 
   # turn an ip into a node name atom, assuming that all other node names looks similar to our own name
-  defp format_node(ip, base_name), do: :"#{base_name}@#{ip |> :inet_parse.ntoa |> to_string()}"
+  defp format_node(ip, base_name), do: :"#{base_name}@#{:inet_parse.ntoa(ip)}"
 
 end

--- a/lib/strategy/dns_poll.ex
+++ b/lib/strategy/dns_poll.ex
@@ -109,7 +109,7 @@ defmodule Cluster.Strategy.DNSPoll do
       Keyword.get(config, :resolver, fn query ->
         query
         |> String.to_charlist()
-        |> :inet_res.lookup(:in, :a)
+        |> lookup_all_ips
       end)
 
     resolve(query, node_basename, resolver, state)
@@ -151,6 +151,11 @@ defmodule Cluster.Strategy.DNSPoll do
     []
   end
 
+  def lookup_all_ips(q) do
+    Enum.map([:a, :aaaa], fn t -> :inet_res.lookup(q, :in, t) end) |> List.flatten
+  end
+
   # turn an ip into a node name atom, assuming that all other node names looks similar to our own name
-  defp format_node({a, b, c, d}, base_name), do: :"#{base_name}@#{a}.#{b}.#{c}.#{d}"
+  defp format_node(ip, base_name), do: :"#{base_name}@#{ip |> :inet_parse.ntoa |> to_string()}"
+
 end

--- a/test/dns_poll_test.exs
+++ b/test/dns_poll_test.exs
@@ -16,7 +16,7 @@ defmodule Cluster.Strategy.DNSPollTest do
             polling_interval: 100,
             query: "app",
             node_basename: "node",
-            resolver: fn _query -> [{10, 0, 0, 1}, {10, 0, 0, 2}] end
+            resolver: fn _query -> [{10, 0, 0, 1}, {10, 0, 0, 2},{10761, 33408, 1, 41584, 47349, 47607, 34961, 243}] end
           ],
           connect: {Nodes, :connect, [self()]},
           disconnect: {Nodes, :disconnect, [self()]},
@@ -26,6 +26,7 @@ defmodule Cluster.Strategy.DNSPollTest do
 
         assert_receive {:connect, :"node@10.0.0.1"}, 100
         assert_receive {:connect, :"node@10.0.0.2"}, 100
+        assert_receive {:connect, :"node@2a09:8280:1:a270:b8f5:b9f7:8891:f3"}, 100
       end)
     end
   end
@@ -111,5 +112,11 @@ defmodule Cluster.Strategy.DNSPollTest do
       refute_receive {:disconnect, _}, 100
       refute_receive {:connect, _}, 100
     end)
+  end
+
+  test "looks up both A and AAAA records" do
+    result = DNSPoll.lookup_all_ips("example.org" |> String.to_charlist)
+    sizes = result |> Enum.map(fn ip -> tuple_size(ip) end) |> Enum.uniq |> Enum.sort
+    assert(sizes == [4,8])
   end
 end


### PR DESCRIPTION
This modifies the DNS poll strategy to lookup AAAA records in addition to A records.

It's useful for discovering IPv6 cluster members, both in IPv6 only environments and dual stack environments.