### PR TITLE
Use :aes_256_cbc instead of retired :aes_cbc256 cypher name

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -261,7 +261,7 @@ defmodule Cluster.Strategy.Gossip do
   defp encrypt(_state, plaintext, password) do
     iv = :crypto.strong_rand_bytes(16)
     key = :crypto.hash(:sha256, password)
-    ciphertext = :crypto.crypto_one_time(:aes_cbc256, key, iv, pkcs7_pad(plaintext), true)
+    ciphertext = :crypto.crypto_one_time(:aes_256_cbc, key, iv, pkcs7_pad(plaintext), true)
 
     {:ok, iv, ciphertext}
   end
@@ -280,7 +280,7 @@ defmodule Cluster.Strategy.Gossip do
 
   defp safe_decrypt(state, key, iv, ciphertext) do
     try do
-      {:ok, :crypto.crypto_one_time(:aes_cbc256, key, iv, ciphertext, false)}
+      {:ok, :crypto.crypto_one_time(:aes_256_cbc, key, iv, ciphertext, false)}
     catch
       :error, {tag, {file, line}, desc} ->
         warn(state.topology, "decryption failed: #{inspect(tag)} (#{file}:#{line}): #{desc}")


### PR DESCRIPTION
### Summary of changes

In the private functions `encrypt/3` and `safe_decrypt/4` retired cypher names were used (`:aes_cbc256`) and because of that they would fail - example for encription:

```elixir
iex(9)> crypted = :crypto.crypto_one_time(:aes_cbc256, key, iv, test_message, true)
** (ErlangError) Erlang error: {:badarg, {'api_ng.c', 141}, 'Unknown cipher'}
    :crypto.ng_crypto_one_time_nif(:aes_cbc256, <<159, 134, 208, 129, 136, 76, 125, 101, 154, 47, 234, 160, 197, 90, 208, 21, 163, 191, 79, 27, 43, 11, 130, 44, 209, 93, 108, 21, 176, 240, 10, 8>>, <<169, 215, 215, 141, 146, 216, 252, 54, 52, 189, 188, 27, 34, 22, 87, 15>>, "This is a test message", true, :undefined)
```

After correcting the cypher name, the encryption works as expected:

```elixir
iex(9)> crypted = :crypto.crypto_one_time(:aes_256_cbc, key, iv, test_message, true)
<<234, 247, 60, 203, 9, 94, 195, 3, 34, 77, 58, 115, 57, 222, 180, 183>>
```

Deprecation of cypher names was done in Erlang OTP 23.0, so in 24.0 they can't be used anymore.