### PR TITLE
Add_membership should use the supplied if address.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Clustering strategy for the Rancher container platform (see: https://github.com/rancher/rancher)
 - LocalEpmd strategy that uses epmd to discover nodes on the local host
+- Gossip strategy multicast interface is used for adding multicast membership
 
 ## 2.0.0
 

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -103,13 +103,15 @@ defmodule Cluster.Strategy.Gossip do
           [
             multicast_if: sanitize_ip(multicast_if),
             multicast_ttl: ttl,
-            multicast_loop: true
+            multicast_loop: true,
+            add_membership: {multicast_addr, sanitize_ip(multicast_if)}
           ]
 
         :else ->
           [
             multicast_ttl: ttl,
-            multicast_loop: true
+            multicast_loop: true,
+            add_membership: {multicast_addr, {0, 0, 0, 0}}
           ]
       end
 
@@ -120,7 +122,6 @@ defmodule Cluster.Strategy.Gossip do
         ip: ip,
         reuseaddr: true,
         broadcast: true,
-        add_membership: {multicast_addr, {0, 0, 0, 0}}
       ] ++ multicast_opts ++ reuse_port()
 
     {:ok, socket} = :gen_udp.open(port, options)


### PR DESCRIPTION
### Summary of changes

Kernels react differently to adding mcast membership to the "0.0.0.0" address depending on how interfaces are set up and how the kernel is configured. 
In some situations, on Linux, the socket won't even receive Any traffic.
There's no perfect way to solve this, but it makes more sense to add the multicast membership to the same interface address being used by the underlying socket. The other option is to allow the user to supply all the interface IPs to listen on or force them to use setsockopts through a function.

This feels like it could break some use cases, but using if_addr doesn't work, since binding and membership can be incompatible in Linux. Using bind_to_interface may be a better move, but that is a pretty big interface change.
I'd be happy to change it to do that, if it's acceptable.


### Checklist

- [ N/A] New functions have typespecs, changed functions were updated
- [ N/A] Same for documentation, including moduledocs
- [ N/A] Tests were added or updated to cover changes
- [ ✓] Commits were squashed into a single coherent commit
- [ ✓] Notes added to CHANGELOG file which describe changes at a high-level
