### PR TITLE
Update k8s strategy documentation

### DIFF
--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -1,5 +1,5 @@
 defmodule Cluster.Strategy.Kubernetes do
-  @moduledoc """
+  @moduledoc ~S"""
   This clustering strategy works by loading all endpoints in the current Kubernetes
   namespace with the configured label. It will fetch the addresses of all endpoints with
   that label and attempt to connect. It will continually monitor and update its
@@ -35,6 +35,15 @@ defmodule Cluster.Strategy.Kubernetes do
 
       # vm.args
       -name app@<%= "${POD_A_RECORD}.${NAMESPACE}.pod.cluster.local" %>
+
+  If you use mix releases instead, you can configure the required options in `rel/env.sh.eex`.
+  Doing so will append a `-name` option to the `start` command directly and requires no further
+  changes to the `vm.args`:
+
+      # rel/env.sh.eex
+      export POD_A_RECORD=$(echo $POD_IP | sed 's/\./-/g')
+      export RELEASE_DISTRIBUTION=name
+      export RELEASE_NODE=<%= @release.name %>@${POD_A_RECORD}.${NAMESPACE}.pod.cluster.local
 
   To set the `NAMESPACE` and `POD_IP` environment variables you can configure your pod as follows:
 


### PR DESCRIPTION
### Summary of changes
Added a short example of `rel/env.sh.eex` to make the kubernetes strategy in `:mode` `:dns` work with releases that have been assembled with `mix release`.

Also changed the doc block to not handle escape characters as the `\` in the sed command got lost.

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [x] Tests were added or updated to cover changes
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
