### PR TITLE
Add `namespace` to Doc Example for DNSSRV

### DIFF
--- a/lib/strategy/kubernetes_dns_srv.ex
+++ b/lib/strategy/kubernetes_dns_srv.ex
@@ -20,6 +20,7 @@ defmodule Cluster.Strategy.Kubernetes.DNSSRV do
             config: [
               service: "elixir-plug-poc",
               application_name: "elixir_plug_poc",
+              namespace: "default",
               polling_interval: 10_000]]]
 
   An example of how this strategy extracts topology information from DNS follows:


### PR DESCRIPTION
Add missing `namespace` to Documentation Example for Strategy.Kubernetes.DNSSRV 
Reference Issue [163](https://github.com/bitwalker/libcluster/issues/163) regarding docs.

### Summary of changes

The required field `namespace` for strategy `Strategy.Kubernetes.DNSSRV` was missing from the Example in the ModuleDoc. This PR is to add the `namespace` to the example.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [X] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
- [] Notes added to CHANGELOG file which describe changes at a high-level
