### PR TITLE
Add an option to activate/deactivate warn messages

### DIFF
--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -12,8 +12,17 @@ defmodule Cluster.Logger do
     end
   end
 
+  def warn(t, msg) do
+    case Application.get_env(:libcluster, :warn, true) do
+      wrn when wrn in [true, :true, "true"] ->
+        Logger.warn(log_message(t, msg))
+
+      _ ->
+        :ok
+    end
+  end
+
   def info(t, msg), do: Logger.info(log_message(t, msg))
-  def warn(t, msg), do: Logger.warn(log_message(t, msg))
   def error(t, msg), do: Logger.error(log_message(t, msg))
 
   @compile {:inline, log_message: 2}


### PR DESCRIPTION
### Summary of changes

Adds a config option to deactivate `warn` messages, so it don't spam those messages in cases with a lot of known nodes that can't be connected to, for example: different applications with different release cookies in the same network, using DNSPoll strategy.

