### PR TITLE
FEAT: Added function callback for kubernetes_node_basename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Use new cypher names
+- Added suppport for `kubernetes_node_basename` to supply a function callback which gets
+the node info as arg supplied. 
 
 ### 3.3.0
 


### PR DESCRIPTION
### Summary of changes

- Updated `kubernetes_node_basename` so that it can be supplied with a function called which allows dynamic node basenames based on the given pod information

Imagine if you have 2 separate apps `oban-workers` & a phoenix `api` both with replicas 2. Now you want to connect them and both have different hostnames, one has `oban`  the other one has `api`.
As a selector you could choose:  `kubernetes_selector: "app in (oban-workers, api)"`
but the `kubernetes_node_basename` is a static variable so far. If you set it to `api` in the phoenix api pod, then it would successful connect to its other replica but fail to connect with the `oban-workers` as it tries to connect with the `api` hostname. 

As a solution with a custom function, this can be dynamically set based on the pod information  
```elixir
kubernetes_node_basename: fn %{labels: %{"app" => app}} ->
        case app do
          "oban-workers" -> "oban"
          "api" -> "api"
        end
      end
```

Hope this makes sense! :) 

Best regards,
Dario