### PR TITLE
added :localhost argument to :erl_empd.names()

### DIFF
--- a/lib/strategy/local_epmd.ex
+++ b/lib/strategy/local_epmd.ex
@@ -27,7 +27,7 @@ defmodule Cluster.Strategy.LocalEpmd do
   defp discover_nodes do
     suffix = get_host_suffix(Node.self())
 
-    {:ok, names} = :erl_epmd.names()
+    {:ok, names} = :erl_epmd.names(:localhost)
     for {n, _} <- names, do: List.to_atom(n ++ suffix)
   end
 


### PR DESCRIPTION
I was using the library with one of my projects, and today I got myself a new dedicated server from the german ionos cloud, and I tried to run an elixir mix release of one of my applications directly on the server. (both build machine and server are Ubuntu 22.04 lts, amd64)
But it did not work, when I was debugging the issue, I noticed that :erl_epmd.names was causing the bug. 
The bug is of the nature that it hangs up for ~30 seconds before returning a {:error, :address}, thus causing libcluster to crash the application. I tried installing erlang libraries on the server but it does not fix anything. 
However, then I added the :localhost atom as the argument to :erl_epmd.names() function call, it fixed the issue and now everything works as intended. It is very strange because localhost is supposed to be the default value. 
I am not able to delve deeper into the issue then this surface-level analysis, as I did not find anything online, and I am not an expert on the low-level erlang stuff. 
However, this is a working fix, I tried it in other environments, and it works as expected. I want to stress that I have never had this issue before with different servers, perhaps it is caused by strange server defaults, which are a thing with ionos.
If you have any other questions regarding this issue, feel free to ask me I will help you out in any way I can. For my own deployment, I have made a custom Cluster. Strategy, so it works either way for me, however, I hope with this fix a similar issue might be avoided for someone else. 

Cheers