### PR TITLE
Improve the moduledocs of Kubernetes related strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ get the config that `Cluster.Supervisor` expects.
 ```elixir
 config :libcluster,
   topologies: [
-    example: [
+    epmd_example: [
       # The selected clustering strategy. Required.
       strategy: Cluster.Strategy.Epmd,
       # Configuration for the provided strategy. Optional.
@@ -93,6 +93,10 @@ config :libcluster,
       # The function to use for listing nodes.
       # This function must return a list of node names. Optional
       list_nodes: {:erlang, :nodes, [:connected]},
+    ],
+    # more topologies can be added ...
+    gossip_example: [
+      # ...
     ]
   ]
 ```

--- a/lib/strategy/state.ex
+++ b/lib/strategy/state.ex
@@ -1,5 +1,7 @@
 defmodule Cluster.Strategy.State do
-  @moduledoc false
+  @moduledoc """
+  The state of one strategy.
+  """
 
   @type t :: %__MODULE__{
           topology: atom,


### PR DESCRIPTION
When reading the docs of Kubernetes related strategies, some details are missing, which makes me confusing. So, I decided to add the details which could be helpful for other developers.

This PR tries to improve the moduledocs of Kubernetes related strategies. It includes:
+ describing the configuration options in detail.
+ describing the working mechanism briefly.
+ describing how to setup kubernetes.
+ describing how to setup `mix release`.
+ improving the structure of docs.

And, it also:
+ fixes a warning when running `mix docs`.
+ demonstrates how to start clustering for one or more topologies in `README.md`

---

Thanks @rlipscombe for writing [the great blog post](https://blog.differentpla.net/blog/2022/01/08/libcluster-kubernetes/), which is the cornerstone of these modifications.

---

Feel free to comment or modify this PR. Have a good day. ;)

