### PR TITLE
Add Linux reuse port

### DIFF
--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -141,7 +141,7 @@ defmodule Cluster.Strategy.Gossip do
     case :os.type() do
       {:unix, os_name} ->
         cond do
-          os_name in [:darwin, :freebsd, :openbsd, :netbsd] ->
+          os_name in [:darwin, :freebsd, :openbsd, :linux, :netbsd] ->
             [{:raw, @sol_socket, @so_reuseport, <<1::native-32>>}]
 
           true ->


### PR DESCRIPTION
This change fix the https://github.com/bitwalker/libcluster/issues/184

This PR worked in conjunction with the following Gossip strategy setups:

```elixir
defp get_gossip_strategy do
    [
      proxy: [
        strategy: Cluster.Strategy.Gossip,
        config: [
          reuseaddr: true,
          multicast_addr: "255.255.255.255",
          broadcast_only: true
        ]
      ]
    ]
  end
```

The image below shows my system connected to two Nodes after changing the PR and settings. Using the settings in the current version has not been shown to have any effect. In other words, only with the PR change did the system reconnect again.

![libcluster](https://user-images.githubusercontent.com/342502/214698746-af4351ce-7c7e-47a9-9d51-db58e21fb2da.png)
