### PR TITLE
Detect Self Signed Certificate Authority for Kubernetes Strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Use new cypher names
+- Detect Self Signed Certificate Authority for Kubernetes Strategy
 
 ### 3.3.0
 


### PR DESCRIPTION
### Summary of changes

Kubernetes provides a `ca.crt` file by default in `/var/run/secrets/kubernetes.io/serviceaccount`. That one can be used to verify the TLS cert of the kubernetes API.

Resolves #193 

### Checklist

- [x] New functions have typespecs, changed functions were updated
- [x] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
  * This is not simple to test without actually generating a CA cert and running a server. How would you like to proceed?
- [x] Commits were squashed into a single coherent commit
- [x] Notes added to CHANGELOG file which describe changes at a high-level
