### PR TITLE
Fix usage of deprecated Logger.warn/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Use new cypher names
+- Remove calls to deprecated `Logger.warn/2`
 
 ### 3.3.0
 

--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -13,7 +13,13 @@ defmodule Cluster.Logger do
   end
 
   def info(t, msg), do: Logger.info(log_message(t, msg))
-  def warn(t, msg), do: Logger.warn(log_message(t, msg))
+
+  if Version.match?(System.version(), ">= 1.11.0") do
+    def warn(t, msg), do: Logger.warning(log_message(t, msg))
+  else
+    def warn(t, msg), do: Logger.warn(log_message(t, msg))
+  end
+
   def error(t, msg), do: Logger.error(log_message(t, msg))
 
   @compile {:inline, log_message: 2}


### PR DESCRIPTION
### Summary of changes

`Logger.warn/2` is deprecated in Elixir 1.15, `Logger.warning/2` should be used instead (which has been added in Elixir 1.11).

As Elixir 1.8 is still supported by this package, we only use `Logger.warning/2` if it exists.

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [X] Commits were squashed into a single coherent commit
- [X] Notes added to CHANGELOG file which describe changes at a high-level
