### PR TITLE
Flag to disable pruning the node list in Cluster.Strategy.DNSPoll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Allow Epmd strategy to reconnect after connection failures
 - Detect Self Signed Certificate Authority for Kubernetes Strategy
 - Remove calls to deprecated `Logger.warn/2`
+- Prune flag for DNSPoll strategy
 
 ### 3.3.0
 


### PR DESCRIPTION
As discussed in issue #190 added a flag to keep nodes once received in DNS response. 