### PR TITLE
Fix compilation warnings on Elixir 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Detect Self Signed Certificate Authority for Kubernetes Strategy
 - Remove calls to deprecated `Logger.warn/2`
 - Correct misspell of 'Empd' -> 'Epmd' in `Cluster.Strategy.LocalEpmd` moduledoc
+- Fix charlist compilation warnings in Elixir 1.17
 
 ### 3.3.0
 

--- a/lib/strategy/gossip.ex
+++ b/lib/strategy/gossip.ex
@@ -130,7 +130,7 @@ defmodule Cluster.Strategy.Gossip do
     state = %State{state | :meta => {multicast_addr, port, socket, secret}}
 
     # TODO: Remove this version check when we deprecate OTP < 21 support
-    if :erlang.system_info(:otp_release) >= '21' do
+    if :erlang.system_info(:otp_release) >= ~c'21' do
       {:ok, state, {:continue, nil}}
     else
       {:ok, state, 0}
@@ -166,7 +166,7 @@ defmodule Cluster.Strategy.Gossip do
 
   # Send stuttered heartbeats
   # TODO: Remove this version check when we deprecate OTP < 21 support
-  if :erlang.system_info(:otp_release) >= '21' do
+  if :erlang.system_info(:otp_release) >= ~c'21' do
     @impl true
     def handle_continue(_, state), do: handle_info(:heartbeat, state)
   else

--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -388,10 +388,10 @@ defmodule Cluster.Strategy.Kubernetes do
             :pods -> "api/v1/namespaces/#{namespace}/pods?labelSelector=#{selector}"
           end
 
-        headers = [{'authorization', 'Bearer #{token}'}]
+        headers = [{~c'authorization', ~c'Bearer #{token}'}]
         http_options = [ssl: ssl_opts, timeout: 15000]
 
-        case :httpc.request(:get, {'https://#{master}/#{path}', headers}, http_options, []) do
+        case :httpc.request(:get, {~c'https://#{master}/#{path}', headers}, http_options, []) do
           {:ok, {{_version, 200, _status}, _headers, body}} ->
             parse_response(ip_lookup_mode, Jason.decode!(body))
             |> Enum.map(fn node_info ->

--- a/lib/strategy/local_epmd.ex
+++ b/lib/strategy/local_epmd.ex
@@ -37,7 +37,7 @@ defmodule Cluster.Strategy.LocalEpmd do
 
   defp get_host_suffix(self) do
     self = Atom.to_charlist(self)
-    [_, suffix] = :string.split(self, '@')
-    '@' ++ suffix
+    [_, suffix] = :string.split(self, ~c'@')
+    ~c'@' ++ suffix
   end
 end

--- a/lib/strategy/rancher.ex
+++ b/lib/strategy/rancher.ex
@@ -130,11 +130,11 @@ defmodule Cluster.Strategy.Rancher do
     case Keyword.fetch!(config, :node_basename) do
       app_name when is_binary(app_name) and app_name != "" ->
         endpoints_path = "latest/self/service"
-        headers = [{'accept', 'application/json'}]
+        headers = [{~c'accept', ~c'application/json'}]
 
         case :httpc.request(
                :get,
-               {'#{@rancher_metadata_base_url}/#{endpoints_path}', headers},
+               {~c'#{@rancher_metadata_base_url}/#{endpoints_path}', headers},
                [],
                []
              ) do

--- a/test/kubernetes_dns_srv_test.exs
+++ b/test/kubernetes_dns_srv_test.exs
@@ -23,10 +23,10 @@ defmodule Cluster.Strategy.KubernetesSRVDNSTest do
               application_name: "node",
               resolver: fn _query ->
                 {:ok,
-                 {:hostent, 'elixir-plug-poc.default.svc.cluster.local', [], :srv, 2,
+                 {:hostent, ~c'elixir-plug-poc.default.svc.cluster.local', [], :srv, 2,
                   [
-                    {10, 50, 0, 'elixir-plug-poc-0.elixir-plug-poc.default.svc.cluster.local'},
-                    {10, 50, 0, 'elixir-plug-poc-1.elixir-plug-poc.default.svc.cluster.local'}
+                    {10, 50, 0, ~c'elixir-plug-poc-0.elixir-plug-poc.default.svc.cluster.local'},
+                    {10, 50, 0, ~c'elixir-plug-poc-1.elixir-plug-poc.default.svc.cluster.local'}
                   ]}}
               end
             ],
@@ -59,9 +59,9 @@ defmodule Cluster.Strategy.KubernetesSRVDNSTest do
               application_name: "node",
               resolver: fn _query ->
                 {:ok,
-                 {:hostent, 'elixir-plug-poc.default.svc.cluster.local', [], :srv, 1,
+                 {:hostent, ~c'elixir-plug-poc.default.svc.cluster.local', [], :srv, 1,
                   [
-                    {10, 50, 0, 'elixir-plug-poc-0.elixir-plug-poc.default.svc.cluster.local'}
+                    {10, 50, 0, ~c'elixir-plug-poc-0.elixir-plug-poc.default.svc.cluster.local'}
                   ]}}
               end
             ],
@@ -102,9 +102,9 @@ defmodule Cluster.Strategy.KubernetesSRVDNSTest do
               application_name: "node",
               resolver: fn _query ->
                 {:ok,
-                 {:hostent, 'elixir-plug-poc.default.svc.cluster.local', [], :srv, 2,
+                 {:hostent, ~c'elixir-plug-poc.default.svc.cluster.local', [], :srv, 2,
                   [
-                    {10, 50, 0, 'elixir-plug-poc-1.elixir-plug-poc.default.svc.cluster.local'}
+                    {10, 50, 0, ~c'elixir-plug-poc-1.elixir-plug-poc.default.svc.cluster.local'}
                   ]}}
               end
             ],

--- a/test/kubernetes_dns_test.exs
+++ b/test/kubernetes_dns_test.exs
@@ -21,7 +21,7 @@ defmodule Cluster.Strategy.KubernetesDNSTest do
               service: "app",
               application_name: "node",
               resolver: fn _query ->
-                {:ok, {:hostent, 'app', [], :inet, 4, [{10, 0, 0, 1}, {10, 0, 0, 2}]}}
+                {:ok, {:hostent, ~c'app', [], :inet, 4, [{10, 0, 0, 1}, {10, 0, 0, 2}]}}
               end
             ],
             connect: {Nodes, :connect, [self()]},
@@ -45,7 +45,7 @@ defmodule Cluster.Strategy.KubernetesDNSTest do
               polling_interval: 100,
               service: "app",
               application_name: "node",
-              resolver: fn _query -> {:ok, {:hostent, 'app', [], :inet, 4, [{10, 0, 0, 1}]}} end
+              resolver: fn _query -> {:ok, {:hostent, ~c'app', [], :inet, 4, [{10, 0, 0, 1}]}} end
             ],
             connect: {Nodes, :connect, [self()]},
             disconnect: {Nodes, :disconnect, [self()]},
@@ -68,7 +68,7 @@ defmodule Cluster.Strategy.KubernetesDNSTest do
               polling_interval: 100,
               service: "app",
               application_name: "node",
-              resolver: fn _query -> {:ok, {:hostent, 'app', [], :inet, 4, [{10, 0, 0, 1}]}} end
+              resolver: fn _query -> {:ok, {:hostent, ~c'app', [], :inet, 4, [{10, 0, 0, 1}]}} end
             ],
             connect: {Nodes, :connect, [self()]},
             disconnect: {Nodes, :disconnect, [self()]},


### PR DESCRIPTION
Fixes the following compilation warnings with Elixir 1.17.

```
warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
```
