### PR TITLE
Add resource version parameter for kubernetes strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Add `kubernates_resource_version` option to Kubernetes strategy
+- Add `kubernetes_use_cached_resources` option to Kubernetes strategy
 
 ## 3.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Add `kubernates_resource_version` option to Kubernetes strategy
+
+## 3.4.1
+
 - Use new cypher names
 - Allow Epmd strategy to reconnect after connection failures
 - Detect Self Signed Certificate Authority for Kubernetes Strategy

--- a/lib/strategy/kubernetes.ex
+++ b/lib/strategy/kubernetes.ex
@@ -25,7 +25,7 @@ defmodule Cluster.Strategy.Kubernetes do
      - `:kubernetes_selector`
      - `:kubernetes_service_name`
      - `:kubernetes_ip_lookup_mode`
-     - `:kubernetes_resource_version`
+     - `:kubernetes_use_cached_resources`
      - `:mode`
 
   ## Getting `<basename>`
@@ -71,12 +71,11 @@ defmodule Cluster.Strategy.Kubernetes do
 
   Then, this strategy will fetch the IP of all pods with that label and attempt to connect.
 
-  ### `kubernetes_resource_version` option
+  ### `kubernetes_use_cached_resources` option
 
-  When setting this value, this strategy will use given resource version value to fetch k8s resources,
-  where each modification of the resource increments the resource version.
-
-  If set to `0` kubernetes will use cached version, that may be outdated.
+  When setting this value, this strategy will use cached resource version value to fetch k8s resources.
+  In k8s resources are incremented by 1 on every change, this version will set requested resourceVersion
+  to 0, that will use cached versions of resources, take in mind that this may be outdated or unavailable.
 
   ### `:mode` option
 
@@ -368,7 +367,9 @@ defmodule Cluster.Strategy.Kubernetes do
     service_name = Keyword.get(config, :kubernetes_service_name)
     selector = Keyword.fetch!(config, :kubernetes_selector)
     ip_lookup_mode = Keyword.get(config, :kubernetes_ip_lookup_mode, :endpoints)
-    resource_version = Keyword.get(config, :kubernetes_resource_version, nil)
+
+    use_cache = Keyword.get(config, :kubernetes_use_cached_resources, false)
+    resource_version = if use_cache, do: 0, else: nil
 
     master_name = Keyword.get(config, :kubernetes_master, @kubernetes_master)
     cluster_domain = System.get_env("CLUSTER_DOMAIN", "#{cluster_name}.local")

--- a/test/fixtures/vcr_cassettes/kubernetes.json
+++ b/test/fixtures/vcr_cassettes/kubernetes.json
@@ -45,6 +45,38 @@
         }
       },
       "request_body": "",
+      "url": "https://cluster.localhost./api/v1/namespaces/__libcluster_test/endpoints?labelSelector=app=test_selector&resourceVersion=0"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"kind\":\"EndpointsList\",\"apiVersion\":\"v1\",\"metadata\":{\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"resourceVersion\":\"17042410\"},\"items\":[{\"metadata\":{\"name\":\"development-development\",\"namespace\":\"airatel-service-localization\",\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"uid\":\"7e3faf1e-0294-11e8-bcad-42010a9c01cc\",\"resourceVersion\":\"17037787\",\"creationTimestamp\":\"2018-01-26T12:29:03Z\",\"labels\":{\"app\":\"development\",\"chart\":\"CHART_PLACEHOLDER\"}},\"subsets\":[{\"addresses\":[{\"hostname\":\"my-hostname-0\",\"ip\":\"10.48.33.136\",\"nodeName\":\"gke-jshmrtn-cluster-default-pool-a61da41f-db9x\",\"targetRef\":{\"kind\":\"Pod\",\"namespace\":\"airatel-service-localization\",\"name\":\"development-4292695165-mgq9f\",\"uid\":\"eb0f3e80-0295-11e8-bcad-42010a9c01cc\",\"resourceVersion\":\"17037783\"}}],\"ports\":[{\"name\":\"web\",\"port\":8443,\"protocol\":\"TCP\"}]}]}]}\n",
+      "headers": {
+        "date": "Fri, 26 Jan 2018 13:18:46 GMT",
+        "content-length": "877",
+        "content-type": "application/json"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "***"
+      },
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": {
+          "ssl": "[verify: :verify_none]"
+        }
+      },
+      "request_body": "",
       "url": "https://cluster.localhost./api/v1/namespaces/airatel-service-test/endpoints?labelSelector=app=test_selector"
     },
     "response": {

--- a/test/fixtures/vcr_cassettes/kubernetes_pods.json
+++ b/test/fixtures/vcr_cassettes/kubernetes_pods.json
@@ -30,5 +30,37 @@
       ],
       "type": "ok"
     }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "authorization": "***"
+      },
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": {
+          "ssl": "[verify: :verify_none]"
+        }
+      },
+      "request_body": "",
+      "url": "https://cluster.localhost./api/v1/namespaces/__libcluster_test/pods?labelSelector=app=test_selector&resourceVersion=0"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"kind\":\"PodList\",\"apiVersion\":\"v1\",\"metadata\":{\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"resourceVersion\":\"17042410\"},\"items\":[{\"metadata\":{\"name\":\"development-development\",\"namespace\":\"airatel-service-localization\",\"selfLink\":\"SELFLINK_PLACEHOLDER\",\"uid\":\"7e3faf1e-0294-11e8-bcad-42010a9c01cc\",\"resourceVersion\":\"17037787\",\"creationTimestamp\":\"2018-01-26T12:29:03Z\",\"labels\":{\"app\":\"development\",\"chart\":\"CHART_PLACEHOLDER\"}},\"spec\": { \"hostname\": \"my-hostname-0\" },\"status\":{\"podIP\": \"10.48.33.136\"}}]}\n",
+      "headers": {
+        "date": "Fri, 26 Jan 2018 13:18:46 GMT",
+        "content-length": "877",
+        "content-type": "application/json"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok"
+    }
   }
 ]

--- a/test/kubernetes_test.exs
+++ b/test/kubernetes_test.exs
@@ -81,6 +81,33 @@ defmodule Cluster.Strategy.KubernetesTest do
       end
     end
 
+    test "works with resource version" do
+      use_cassette "kubernetes", custom: true do
+        capture_log(fn ->
+          start_supervised!({Kubernetes,
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_selector: "app=test_selector",
+                 kubernetes_resource_version: 0,
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost.",
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
+
+          assert_receive {:connect, _}, 5_000
+        end)
+      end
+    end
+
     test "works with dns and cluster_name" do
       use_cassette "kubernetes", custom: true do
         capture_log(fn ->
@@ -187,6 +214,34 @@ defmodule Cluster.Strategy.KubernetesTest do
                  # If you want to run the test freshly, you'll need to create a DNS Entry
                  kubernetes_master: "cluster.localhost.",
                  kubernetes_ip_lookup_mode: :pods,
+                 kubernetes_service_account_path:
+                   Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
+               ],
+               connect: {Nodes, :connect, [self()]},
+               disconnect: {Nodes, :disconnect, [self()]},
+               list_nodes: {Nodes, :list_nodes, [[]]}
+             }
+           ]})
+
+          assert_receive {:connect, :"test_basename@10.48.33.136"}, 5_000
+        end)
+      end
+    end
+
+    test "works with pods and resource version" do
+      use_cassette "kubernetes_pods", custom: true do
+        capture_log(fn ->
+          start_supervised!({Kubernetes,
+           [
+             %Cluster.Strategy.State{
+               topology: :name,
+               config: [
+                 kubernetes_node_basename: "test_basename",
+                 kubernetes_selector: "app=test_selector",
+                 # If you want to run the test freshly, you'll need to create a DNS Entry
+                 kubernetes_master: "cluster.localhost.",
+                 kubernetes_ip_lookup_mode: :pods,
+                 kubernetes_resource_version: 0,
                  kubernetes_service_account_path:
                    Path.join([__DIR__, "fixtures", "kubernetes", "service_account"])
                ],


### PR DESCRIPTION
### Summary of changes

#### Why
In enviroment with multiple different application, using same kubernates cluster, many apps may trigger thousends of requests to cluster API to get requested resources. In our case, we talk about 500000 requests per hour. In such a case, direct requests to etcd may impact cluster resources. Solution for such a case may be
- using cached version of resource (implemented in PR)
- using watch to subscribe to changes (investigating possible solutions)

In this PR, as cache should be eventually consistent, I've implemented simples solution for such a issue, aka using cached version of resource instead of direct API call. According do AWS, which is our cluster provider, cache inconsistency should be `few tens of milliseconds` 


#### What
- Add `kubernetes_resource_version` parameter to Kubernates strategy, that allows to select given resource version, in our case, select 0 as a cache. 
- Added test cases for extended api call. 

#### Testing Scenario
- Create k8s cluster & 5 pods that should be connected.
- Ensured that `uri` contains resourceVersion and the nodes are connected 

### Checklist

- [ ] New functions have typespecs, changed functions were updated
- [ ] Same for documentation, including moduledocs
- [ ] Tests were added or updated to cover changes
- [ ] Commits were squashed into a single coherent commit
- [ ] Notes added to CHANGELOG file which describe changes at a high-level
